### PR TITLE
Nicer config handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.out
 
 psk.key
+config.json
 secret.key
 tradfri-go
 build

--- a/dtlscoap/dtlscoap-client.go
+++ b/dtlscoap/dtlscoap-client.go
@@ -2,49 +2,54 @@ package dtlscoap
 
 import (
 	"fmt"
-	"github.com/dustin/go-coap"
-	"github.com/eriklupander/dtls"
-	"github.com/spf13/viper"
 	"os"
 	"time"
+
+	"github.com/dustin/go-coap"
+	"github.com/eriklupander/dtls"
 )
 
 // DtlsClient provides an domain-agnostic CoAP-client with DTLS transport.
 type DtlsClient struct {
-	peer  *dtls.Peer
-	msgId uint16
+	peer           *dtls.Peer
+	msgID          uint16
+	gatewayAddress string
+	clientID       string
+	psk            string
 }
 
 // NewDtlsClient acts as factory function, returns a pointer to a connected (or will panic) DtlsClient.
-func NewDtlsClient() *DtlsClient {
-	client := &DtlsClient{}
+func NewDtlsClient(gatewayAddress, clientID, psk string) *DtlsClient {
+	client := &DtlsClient{
+		gatewayAddress: gatewayAddress,
+		clientID:       clientID,
+		psk:            psk,
+	}
 	client.connect()
 	return client
 }
 
 func (dc *DtlsClient) connect() {
-	setupKeystore()
+	dc.setupKeystore()
 
 	listener, err := dtls.NewUdpListener(":0", time.Second*900)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	gatewayIp := viper.GetString("GATEWAY_IP") + ":5684"
-
 	peerParams := &dtls.PeerParams{
-		Addr:             gatewayIp,
-		Identity:         viper.GetString("CLIENT_ID"),
+		Addr:             dc.gatewayAddress,
+		Identity:         dc.clientID,
 		HandshakeTimeout: time.Second * 15}
-	fmt.Printf("Connecting to peer at %v\n", gatewayIp)
+	fmt.Printf("Connecting to peer at %v\n", dc.gatewayAddress)
 
 	dc.peer, err = listener.AddPeerWithParams(peerParams)
 	if err != nil {
-		fmt.Printf("Unable to connect to Gateway at %v: %v\n", gatewayIp, err.Error())
+		fmt.Printf("Unable to connect to Gateway at %v: %v\n", dc.gatewayAddress, err.Error())
 		os.Exit(1)
 	}
 	dc.peer.UseQueue(true)
-	fmt.Printf("DTLS connection established to %v\n", gatewayIp)
+	fmt.Printf("DTLS connection established to %v\n", dc.gatewayAddress)
 }
 
 // Call writes the supplied coap.Message to the peer
@@ -79,13 +84,13 @@ func (dc *DtlsClient) Call(req coap.Message) (coap.Message, error) {
 	return msg, nil
 }
 
-// BuildGETMessage produces a CoAP GET message with the next msgId set.
+// BuildGETMessage produces a CoAP GET message with the next msgID set.
 func (dc *DtlsClient) BuildGETMessage(path string) coap.Message {
-	dc.msgId++
+	dc.msgID++
 	req := coap.Message{
 		Type:      coap.Confirmable,
 		Code:      coap.GET,
-		MessageID: dc.msgId,
+		MessageID: dc.msgID,
 	}
 	req.SetPathString(path)
 	return req
@@ -94,14 +99,14 @@ func (dc *DtlsClient) BuildGETMessage(path string) coap.Message {
 //req.SetOption(coap.ETag, "weetag")
 //req.SetOption(coap.MaxAge, 3)
 
-// BuildPUTMessage produces a CoAP PUT message with the next msgId set.
+// BuildPUTMessage produces a CoAP PUT message with the next msgID set.
 func (dc *DtlsClient) BuildPUTMessage(path string, payload string) coap.Message {
-	dc.msgId++
+	dc.msgID++
 
 	req := coap.Message{
 		Type:      coap.Confirmable,
 		Code:      coap.PUT,
-		MessageID: dc.msgId,
+		MessageID: dc.msgID,
 		Payload:   []byte(payload),
 	}
 	req.SetPathString(path)
@@ -109,14 +114,14 @@ func (dc *DtlsClient) BuildPUTMessage(path string, payload string) coap.Message 
 	return req
 }
 
-// BuildPOSTMessage produces a CoAP POST message with the next msgId set.
+// BuildPOSTMessage produces a CoAP POST message with the next msgID set.
 func (dc *DtlsClient) BuildPOSTMessage(path string, payload string) coap.Message {
-	dc.msgId++
+	dc.msgID++
 
 	req := coap.Message{
 		Type:      coap.Confirmable,
 		Code:      coap.POST,
-		MessageID: dc.msgId,
+		MessageID: dc.msgID,
 		Payload:   []byte(payload),
 	}
 	req.SetPathString(path)
@@ -124,8 +129,8 @@ func (dc *DtlsClient) BuildPOSTMessage(path string, payload string) coap.Message
 	return req
 }
 
-func setupKeystore() {
+func (dc *DtlsClient) setupKeystore() {
 	mks := dtls.NewKeystoreInMemory()
 	dtls.SetKeyStores([]dtls.Keystore{mks})
-	mks.AddKey(viper.GetString("CLIENT_ID"), []byte(viper.GetString("PRE_SHARED_KEY")))
+	mks.AddKey(dc.clientID, []byte(dc.psk))
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/eriklupander/dtls v0.0.0-20190304211642-b36018226359
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.2
 	github.com/spf13/viper v1.2.1
 	github.com/stretchr/testify v1.2.2 // indirect
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/eriklupander/dtls v0.0.0-20190304211642-b36018226359 h1:GrRdzY4NkR4IG
 github.com/eriklupander/dtls v0.0.0-20190304211642-b36018226359/go.mod h1:9cQp/YAWpoevkrztrrOhFYyeHX8cOvhwHMiwg91o4Eo=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-chi/chi v4.0.1+incompatible h1:RSRC5qmFPtO90t7pTL0DBMNpZFsb/sHF3RXVlDgFisA=
-github.com/go-chi/chi v4.0.1+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/main.go
+++ b/main.go
@@ -1,155 +1,135 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"github.com/eriklupander/tradfri-go/router"
 	"github.com/eriklupander/tradfri-go/tradfri"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"io/ioutil"
 	"os"
-	"os/signal"
-	"strings"
+
 	"sync"
-	"syscall"
 	"time"
 )
 
-var serverMode, authenticate *bool
+var configFlags = pflag.NewFlagSet("config", pflag.ExitOnError)
+var commandFlags = pflag.NewFlagSet("commands", pflag.ExitOnError)
 
 func init() {
-	// dtls.SetLogLevel("debug")
+	configFlags.String("gateway_ip", "", "ip to your gateway. No protocol or port here!")
+	configFlags.String("gateway_address", "", "address to your gateway. Including port here!")
+	configFlags.String("psk", "", "Pre-shared key on bottom of Gateway")
+	configFlags.String("client_id", "", "Your client id, make something up or use the NNN-NNN-NNN on the bottom of your Gateway")
 
-	// read clientId / PSK from file if possible
+	commandFlags.Bool("server", false, "Start in server mode?")
+	commandFlags.Bool("authenticate", false, "Perform PSK exchange")
+	commandFlags.String("get", "", "URL to GET")
+	commandFlags.String("put", "", "URL to PUT")
+	commandFlags.String("payload", "", "payload for PUT")
+	
+	commandFlags.AddFlagSet(configFlags)
+	commandFlags.Parse(os.Args[1:])
+
+	viper.BindPFlags(configFlags)
 	viper.AutomaticEnv()
+	viper.AddConfigPath(".") // e.g. reads ./config.json or config.yaml
+	err := viper.ReadInConfig()
+	if err != nil {
+		fmt.Println(err)
+		fmt.Println("You probably have to run --authenticate first")
+	}
+	viper.RegisterAlias("pre_shared_key", "psk")
 }
 
 func main() {
-	// Really ugly flag / config handling... :(
-	serverMode = flag.Bool("server", false, "Start in server mode?")
-	gatewayIp := flag.String("gateway", "", "ip to your gateway. No protocol or port here!")
-	authenticate = flag.Bool("authenticate", false, "Perform PSK exchange")
-	psk := flag.String("psk", "", "Pre-shared key on bottom of Gateway")
-	clientId := flag.String("clientId", "", "Your client id, make something up or use the NNN-NNN-NNN on the bottom of your Gateway")
-	get := flag.String("get", "", "URL to GET")
-	put := flag.String("put", "", "URL to PUT")
-	payload := flag.String("payload", "", "payload for PUT")
-	flag.Parse()
+	gatewayAddress := viper.GetString("gateway_address")
+	if gatewayAddress == "" {
+		gatewayAddress = viper.GetString("gateway_ip") + ":5684"
+	}
+	psk := viper.GetString("psk")
+	clientID := viper.GetString("client_id")
+	serverMode, _ := commandFlags.GetBool("server")
+	authenticate, _ := commandFlags.GetBool("authenticate")
+	get, getErr := commandFlags.GetString("get")
+	put, putErr := commandFlags.GetString("put")
+	payload, _ := commandFlags.GetString("payload")
 
-	resolveGatewayIP(gatewayIp)
-
-	handleSigterm(nil)
+	fmt.Printf("------------- TODO REMOVE ME ---------\nKeys: %v\n", viper.AllSettings())
 
 	// Handle the special authenticate use-case
-	if *authenticate {
-		performTokenExchange(clientId, psk)
+	if authenticate {
+		performTokenExchange(gatewayAddress, clientID, psk)
 		return
 	}
 
-	ok := resolveClientIdAndPSKFromFile()
-	if !ok {
-		checkRequiredEnvVars()
-	}
+	checkRequiredConfig()
 
 	// Check running mode...
-	if *serverMode {
+	if serverMode {
 		fmt.Println("Running in server mode on :8080")
-		go router.SetupChi(tradfri.NewTradfriClient())
+		go router.SetupChi(tradfri.NewTradfriClient(gatewayAddress, clientID, psk))
 
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		wg.Wait()
 	} else {
 		// client mode
-		if *get != "" {
-			resp, _ := tradfri.NewTradfriClient().Get(*get)
+		if getErr == nil && get != "" {
+			resp, _ := tradfri.NewTradfriClient(gatewayAddress, clientID, psk).Get(get)
 			fmt.Printf("%v", string(resp.Payload))
-		} else if *put != "" {
-			resp, _ := tradfri.NewTradfriClient().Put(*put, *payload)
+		} else if putErr == nil && put != "" {
+			resp, _ := tradfri.NewTradfriClient(gatewayAddress, clientID, psk).Put(put, payload)
 			fmt.Printf("%v", string(resp.Payload))
 		} else {
-			fmt.Println("No client operation was specified, supported one(s) are: authenticate")
+			fmt.Println("No client operation was specified, supported one(s) are: get, put, authenticate")
 		}
 	}
 
 }
 
-func checkRequiredEnvVars() {
+func checkRequiredConfig() {
 	if viper.GetString("PRE_SHARED_KEY") == "" {
-		panic("Unable to resolve PRE_SHARED_KEY from env-var or psk.key file")
+		fail("Unable to resolve PRE_SHARED_KEY from env-var or psk.key file")
 	}
 	if viper.GetString("CLIENT_ID") == "" {
-		panic("Unable to resolve CLIENT_ID from env-var or psk.key file")
+		fail("Unable to resolve CLIENT_ID from env-var or psk.key file")
 	}
 }
 
-func resolveGatewayIP(gatewayIp *string) {
-	if viper.GetString("GATEWAY_IP") == "" {
-		if *gatewayIp != "" {
-			viper.Set("GATEWAY_IP", *gatewayIp)
-		} else {
-			panic("Unable to resolve gateway IP from either of env var GATEWAY_IP or flag -gateway")
+func performTokenExchange(gatewayAddress, clientID, psk string) {
+	if len(clientID) < 1 || len(psk) < 10 {
+		fail("Both clientID and psk args must be specified when performing key exchange")
+	}
+
+	done := make(chan bool)
+	defer func() { done <- true }()
+	go func() {
+		select {
+		case <-time.After(time.Second * 5):
+			fmt.Println("(Please note that the key exchange may appear to be stuck at \"Connecting to peer at\" if the PSK from the bottom of your Gateway is not entered correctly.)")
+		case <-done:
 		}
-	}
-}
-
-func resolveClientIdAndPSKFromFile() bool {
-	data, err := ioutil.ReadFile("psk.key")
-	if err != nil {
-		fmt.Println("Could not find psk.key in current directory, trying to use env-vars CLIENT_ID and PRE_SHARED_KEY instead")
-		return false
-	}
-	str := string(data)
-	if !strings.Contains(str, "=") {
-		panic("Invalid psk.key, must contain a single line with [clientId]=[PSK]. No = found")
-	}
-	parts := strings.Split(str, "=")
-	if len(parts) != 2 {
-		panic("Invalid psk.key, must contain a single line with [clientId]=[PSK], could not split into two parts")
-	}
-	viper.Set("CLIENT_ID", parts[0])
-	viper.Set("PRE_SHARED_KEY", parts[1])
-	return true
-}
-
-func performTokenExchange(clientId *string, psk *string) {
-	if len(*clientId) < 1 || len(*psk) < 10 {
-		panic("Both clientId and psk args must be specified when performing key exchange")
-	}
+	}()
 
 	// Note that we hard-code "Client_identity" here before creating the DTLS client,
 	// required when performing token exchange
-	viper.Set("CLIENT_ID", "Client_identity")
-	viper.Set("PRE_SHARED_KEY", *psk)
+	dtlsClient := tradfri.NewTradfriClient(gatewayAddress, "Client_identity", psk)
 
-	go func() {
-		time.Sleep(time.Second * 5)
-		fmt.Println("(Please note that the key exchange may appear to be stuck at \"Connecting to peer at\" if the PSK from the bottom of your Gateway is not entered correctly.)")
-	}()
-
-	dtlsClient := tradfri.NewTradfriClient()
-
-	authToken, err := dtlsClient.AuthExchange(*clientId)
+	authToken, err := dtlsClient.AuthExchange(clientID)
 	if err != nil {
-		panic(err.Error())
+		fail(err.Error())
 	}
-	d1 := []byte(*clientId + "=" + authToken.Token)
-	err = ioutil.WriteFile("psk.key", d1, 0644)
+	viper.Set("client_id", clientID)
+	viper.Set("gateway_address", gatewayAddress)
+	viper.Set("psk", authToken.Token)
+	err = viper.WriteConfigAs("config.json")
 	if err != nil {
-		panic(err.Error())
+		fail(err.Error())
 	}
-	fmt.Println("Your new PSK and clientId has been written to psk.key, keep this file safe!")
+	fmt.Println("Your new PSK and clientID has been written to psk.key, keep this file safe!")
 }
 
-// Handles Ctrl+C or most other means of "controlled" shutdown gracefully. Invokes the supplied func before exiting.
-func handleSigterm(handleExit func()) {
-	c := make(chan os.Signal, 2)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-c
-		if handleExit != nil {
-			handleExit()
-		}
-		os.Exit(1)
-	}()
+func fail(msg string) {
+	fmt.Println(msg)
+	os.Exit(1)
 }

--- a/tradfri/tradfri-client.go
+++ b/tradfri/tradfri-client.go
@@ -14,9 +14,9 @@ type TradfriClient struct {
 	dtlsclient *dtlscoap.DtlsClient
 }
 
-func NewTradfriClient() *TradfriClient {
+func NewTradfriClient(gatewayAddress, clientID, psk string) *TradfriClient {
 	client := &TradfriClient{}
-	client.dtlsclient = dtlscoap.NewDtlsClient()
+	client.dtlsclient = dtlscoap.NewDtlsClient(gatewayAddress, clientID, psk)
 	return client
 }
 


### PR DESCRIPTION
Unfortunately this got larger than I wanted... My starting issue was, why I had to enter the gateway IP all the time although it never changes.

This PR now includes:
* properly use viper. Overriding of flag, env, config file is all done automatically. This includes also flags - unfortunately this means "-xyz" is not valid anymore and you have to use "--xyz"
  * remove viper dependency from lower layers. This made the code hard to follow as changes at one point were referenced much deeper in the stack
* split command and config in flags. This allows to later save the whole config.
* go fmt, go lint. VS Code doesn't show any warnings anymore :-)
