### PR TITLE
Blind control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.13
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+EXPOSE 8080
+EXPOSE 8081
+
+CMD ["tradfri-go", "--server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go get -d -v ./...
 RUN go install -v ./...
 
-EXPOSE 8080
-EXPOSE 8081
+EXPOSE 80
+EXPOSE 81
 
 CMD ["tradfri-go", "--server"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tradfri-go
+# tradfri-go(-blind-server)
 
 [![CircleCI](https://circleci.com/gh/eriklupander/tradfri-go.svg?style=svg)](https://circleci.com/gh/eriklupander/tradfri-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/eriklupander/tradfri-go)](https://goreportcard.com/report/github.com/eriklupander/tradfri-go)
@@ -27,21 +27,24 @@ https://github.com/eriklupander/tradfri-go
 - 2019-03-10: Initial release
 
 ### Compatibility
-tradfri-go has been tested against the following DTLS-enabled COAP servers:
+tradfri-go(-blind-server) has been tested against the following DTLS-enabled COAP servers:
 
 - IKEA Trådfri Gateway using PSK after token exchange: OK
-- Californicum COAP server on Scandium DTLS: OK
 
 ### Building
 Uses go modules.
 
     export GO111MODULE=on
     go build -o tradfri-go
-    
+
+or Use a golang:1.13 docker container to build tradfri-go(-blind-server)
+
+    ./build.sh .
+
 ### PSK exchange
 The Trådfri gateway has its Pre-shared key (PSK) printed on the bottom sticker. However, that PSK is only used for making an initial exchange where you specify a unique _Client_id_ and the original PSK, and you get a new PSK in return that you use for subsequent interactions with the gateway.
 
-_tradfri-go_ supports this operation out of the box using the following command:
+_tradfri-go(-blind-server)_ supports this operation out of the box using the following command:
 
     > ./tradfri-go --authenticate --client_id=MyCoolID --psk=TheKeyAtTheBottomOfYourGateway --gateway_ip=<ip to your gateway>
 
@@ -57,7 +60,7 @@ The generated new PSK and settings used are stored in the current directory in t
       "loglevel":"info"
     }
     
-_tradfri-go_ will try to read _config.json_ when starting up, and will in that case set the required properties accordingly.
+_tradfri-go(-blind-server)_ will try to read _config.json_ when starting up, and will in that case set the required properties accordingly.
 
 If you don't feel like using _config.json_, you can either specify the configuration as command-line flags or using the following environment variables:
 
@@ -74,12 +77,12 @@ Configuration is resolved in the following order of precedence:
 config.json -> command-line arguments -> environment variables
     
 ### Determine gateway IP
-_tradfri-go_ has no means of finding out the IP of the Gateway. I suggest checking your Router's list of connected devices and try to find an item starting with "GW-".
+_tradfri-go(-blind-server)_ has no means of finding out the IP of the Gateway. I suggest checking your Router's list of connected devices and try to find an item starting with "GW-".
 
 ### Running in server mode
 Server mode connects to your gateway and then publishes a really simple RESTful interface and a gRPC service for querying your gateway or mutating some state on blinds:
 
-    ./tradfri-go --server
+    docker-compose up -d
     
 Now, you can use the simple RESTful API provided by tradfri-go which returns more human-readable responses than the raw CoAP responses:
 
@@ -87,7 +90,7 @@ Now, you can use the simple RESTful API provided by tradfri-go which returns mor
     {
       "deviceMetadata": {
         "id": 65541,
-        "name": "left",
+        "name": "Living Room Left Blind",
         "vendor": "IKEA of Sweden",
         "type": "FYRTUR block-out roller blind",
         "battery": 90

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-docker build -t dl-tradfri-go ${1}
+if [ -z ${1} ]; then
+	echo "No path giving. Using current path: $(pwd)"
+	path=$(pwd)
+else
+	path=${1}
+fi
+
+docker build -t tradfri-go-blind-server ${path}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t dl-tradfri-go ${1}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+    tradfri-go:
+        container_name: tradfri-go
+        image: tradfri-go-blind-server
+        ports:
+          - "8080:8080"
+          - "8081:8081"
+        restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ services:
         container_name: tradfri-go
         image: tradfri-go-blind-server
         ports:
-          - "8080:8080"
-          - "8081:8081"
+          - "80:80"
+          - "81:81"
         restart: unless-stopped

--- a/grpc_server/golang/tradfri.pb.go
+++ b/grpc_server/golang/tradfri.pb.go
@@ -27,6 +27,7 @@ type DeviceMetadata struct {
 	Name                 string   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	Vendor               string   `protobuf:"bytes,3,opt,name=vendor,proto3" json:"vendor,omitempty"`
 	Type                 string   `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty"`
+	Battery              int      `protobuf:"bytes,10,opt,name=battery,proto3" json:"battery,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -85,13 +86,16 @@ func (m *DeviceMetadata) GetType() string {
 	return ""
 }
 
+func (m *DeviceMetadata) GetBattery() int {
+	if m != nil {
+		return m.Battery
+	}
+	return 0
+}
+
 type Device struct {
 	Metadata             *DeviceMetadata `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	Dimmer               int32           `protobuf:"varint,2,opt,name=dimmer,proto3" json:"dimmer,omitempty"`
-	Xcolor               int32           `protobuf:"varint,3,opt,name=xcolor,proto3" json:"xcolor,omitempty"`
-	Ycolor               int32           `protobuf:"varint,4,opt,name=ycolor,proto3" json:"ycolor,omitempty"`
-	Rgb                  string          `protobuf:"bytes,5,opt,name=rgb,proto3" json:"rgb,omitempty"`
-	Power                bool            `protobuf:"varint,6,opt,name=power,proto3" json:"power,omitempty"`
+	Position             float32         `protobuf:"varint,2,opt,name=position,proto3" json:"position,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
 	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
@@ -129,44 +133,15 @@ func (m *Device) GetMetadata() *DeviceMetadata {
 	return nil
 }
 
-func (m *Device) GetDimmer() int32 {
+func (m *Device) GetPosition() float32 {
 	if m != nil {
-		return m.Dimmer
+		return m.Position
 	}
 	return 0
-}
-
-func (m *Device) GetXcolor() int32 {
-	if m != nil {
-		return m.Xcolor
-	}
-	return 0
-}
-
-func (m *Device) GetYcolor() int32 {
-	if m != nil {
-		return m.Ycolor
-	}
-	return 0
-}
-
-func (m *Device) GetRgb() string {
-	if m != nil {
-		return m.Rgb
-	}
-	return ""
-}
-
-func (m *Device) GetPower() bool {
-	if m != nil {
-		return m.Power
-	}
-	return false
 }
 
 type Group struct {
 	Id                   int32    `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Power                int32    `protobuf:"varint,2,opt,name=power,proto3" json:"power,omitempty"`
 	Created              string   `protobuf:"bytes,3,opt,name=created,proto3" json:"created,omitempty"`
 	Devices              []int32  `protobuf:"varint,4,rep,packed,name=devices,proto3" json:"devices,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -202,13 +177,6 @@ var xxx_messageInfo_Group proto.InternalMessageInfo
 func (m *Group) GetId() int32 {
 	if m != nil {
 		return m.Id
-	}
-	return 0
-}
-
-func (m *Group) GetPower() int32 {
-	if m != nil {
-		return m.Power
 	}
 	return 0
 }
@@ -609,101 +577,7 @@ func (m *GetDeviceResponse) GetDevice() *Device {
 	return nil
 }
 
-type ChangeDeviceColorRequest struct {
-	Id                   int32    `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Xcolor               int32    `protobuf:"varint,2,opt,name=xcolor,proto3" json:"xcolor,omitempty"`
-	Ycolor               int32    `protobuf:"varint,3,opt,name=ycolor,proto3" json:"ycolor,omitempty"`
-	Rgb                  string   `protobuf:"bytes,4,opt,name=rgb,proto3" json:"rgb,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *ChangeDeviceColorRequest) Reset()         { *m = ChangeDeviceColorRequest{} }
-func (m *ChangeDeviceColorRequest) String() string { return proto.CompactTextString(m) }
-func (*ChangeDeviceColorRequest) ProtoMessage()    {}
-func (*ChangeDeviceColorRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7f669820b67678c6, []int{13}
-}
-
-func (m *ChangeDeviceColorRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ChangeDeviceColorRequest.Unmarshal(m, b)
-}
-func (m *ChangeDeviceColorRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ChangeDeviceColorRequest.Marshal(b, m, deterministic)
-}
-func (m *ChangeDeviceColorRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ChangeDeviceColorRequest.Merge(m, src)
-}
-func (m *ChangeDeviceColorRequest) XXX_Size() int {
-	return xxx_messageInfo_ChangeDeviceColorRequest.Size(m)
-}
-func (m *ChangeDeviceColorRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ChangeDeviceColorRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ChangeDeviceColorRequest proto.InternalMessageInfo
-
-func (m *ChangeDeviceColorRequest) GetId() int32 {
-	if m != nil {
-		return m.Id
-	}
-	return 0
-}
-
-func (m *ChangeDeviceColorRequest) GetXcolor() int32 {
-	if m != nil {
-		return m.Xcolor
-	}
-	return 0
-}
-
-func (m *ChangeDeviceColorRequest) GetYcolor() int32 {
-	if m != nil {
-		return m.Ycolor
-	}
-	return 0
-}
-
-func (m *ChangeDeviceColorRequest) GetRgb() string {
-	if m != nil {
-		return m.Rgb
-	}
-	return ""
-}
-
-type ChangeDeviceColorResponse struct {
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *ChangeDeviceColorResponse) Reset()         { *m = ChangeDeviceColorResponse{} }
-func (m *ChangeDeviceColorResponse) String() string { return proto.CompactTextString(m) }
-func (*ChangeDeviceColorResponse) ProtoMessage()    {}
-func (*ChangeDeviceColorResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7f669820b67678c6, []int{14}
-}
-
-func (m *ChangeDeviceColorResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ChangeDeviceColorResponse.Unmarshal(m, b)
-}
-func (m *ChangeDeviceColorResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ChangeDeviceColorResponse.Marshal(b, m, deterministic)
-}
-func (m *ChangeDeviceColorResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ChangeDeviceColorResponse.Merge(m, src)
-}
-func (m *ChangeDeviceColorResponse) XXX_Size() int {
-	return xxx_messageInfo_ChangeDeviceColorResponse.Size(m)
-}
-func (m *ChangeDeviceColorResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ChangeDeviceColorResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ChangeDeviceColorResponse proto.InternalMessageInfo
-
-type ChangeDeviceDimmingRequest struct {
+type ChangeDevicePositioningRequest struct {
 	Id                   int32    `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	Value                int32    `protobuf:"varint,2,opt,name=value,proto3" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -711,215 +585,75 @@ type ChangeDeviceDimmingRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ChangeDeviceDimmingRequest) Reset()         { *m = ChangeDeviceDimmingRequest{} }
-func (m *ChangeDeviceDimmingRequest) String() string { return proto.CompactTextString(m) }
-func (*ChangeDeviceDimmingRequest) ProtoMessage()    {}
-func (*ChangeDeviceDimmingRequest) Descriptor() ([]byte, []int) {
+func (m *ChangeDevicePositioningRequest) Reset()         { *m = ChangeDevicePositioningRequest{} }
+func (m *ChangeDevicePositioningRequest) String() string { return proto.CompactTextString(m) }
+func (*ChangeDevicePositioningRequest) ProtoMessage()    {}
+func (*ChangeDevicePositioningRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_7f669820b67678c6, []int{15}
 }
 
-func (m *ChangeDeviceDimmingRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ChangeDeviceDimmingRequest.Unmarshal(m, b)
+func (m *ChangeDevicePositioningRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ChangeDevicePositioningRequest.Unmarshal(m, b)
 }
-func (m *ChangeDeviceDimmingRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ChangeDeviceDimmingRequest.Marshal(b, m, deterministic)
+func (m *ChangeDevicePositioningRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ChangeDevicePositioningRequest.Marshal(b, m, deterministic)
 }
-func (m *ChangeDeviceDimmingRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ChangeDeviceDimmingRequest.Merge(m, src)
+func (m *ChangeDevicePositioningRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ChangeDevicePositioningRequest.Merge(m, src)
 }
-func (m *ChangeDeviceDimmingRequest) XXX_Size() int {
-	return xxx_messageInfo_ChangeDeviceDimmingRequest.Size(m)
+func (m *ChangeDevicePositioningRequest) XXX_Size() int {
+	return xxx_messageInfo_ChangeDevicePositioningRequest.Size(m)
 }
-func (m *ChangeDeviceDimmingRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ChangeDeviceDimmingRequest.DiscardUnknown(m)
+func (m *ChangeDevicePositioningRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ChangeDevicePositioningRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ChangeDeviceDimmingRequest proto.InternalMessageInfo
+var xxx_messageInfo_ChangeDevicePositioningRequest proto.InternalMessageInfo
 
-func (m *ChangeDeviceDimmingRequest) GetId() int32 {
+func (m *ChangeDevicePositioningRequest) GetId() int32 {
 	if m != nil {
 		return m.Id
 	}
 	return 0
 }
 
-func (m *ChangeDeviceDimmingRequest) GetValue() int32 {
+func (m *ChangeDevicePositioningRequest) GetValue() int32 {
 	if m != nil {
 		return m.Value
 	}
 	return 0
 }
 
-type ChangeDeviceDimmingResponse struct {
+type ChangeDevicePositioningResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ChangeDeviceDimmingResponse) Reset()         { *m = ChangeDeviceDimmingResponse{} }
-func (m *ChangeDeviceDimmingResponse) String() string { return proto.CompactTextString(m) }
-func (*ChangeDeviceDimmingResponse) ProtoMessage()    {}
-func (*ChangeDeviceDimmingResponse) Descriptor() ([]byte, []int) {
+func (m *ChangeDevicePositioningResponse) Reset()         { *m = ChangeDevicePositioningResponse{} }
+func (m *ChangeDevicePositioningResponse) String() string { return proto.CompactTextString(m) }
+func (*ChangeDevicePositioningResponse) ProtoMessage()    {}
+func (*ChangeDevicePositioningResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_7f669820b67678c6, []int{16}
 }
 
-func (m *ChangeDeviceDimmingResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ChangeDeviceDimmingResponse.Unmarshal(m, b)
+func (m *ChangeDevicePositioningResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ChangeDevicePositioningResponse.Unmarshal(m, b)
 }
-func (m *ChangeDeviceDimmingResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ChangeDeviceDimmingResponse.Marshal(b, m, deterministic)
+func (m *ChangeDevicePositioningResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ChangeDevicePositioningResponse.Marshal(b, m, deterministic)
 }
-func (m *ChangeDeviceDimmingResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ChangeDeviceDimmingResponse.Merge(m, src)
+func (m *ChangeDevicePositioningResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ChangeDevicePositioningResponse.Merge(m, src)
 }
-func (m *ChangeDeviceDimmingResponse) XXX_Size() int {
-	return xxx_messageInfo_ChangeDeviceDimmingResponse.Size(m)
+func (m *ChangeDevicePositioningResponse) XXX_Size() int {
+	return xxx_messageInfo_ChangeDevicePositioningResponse.Size(m)
 }
-func (m *ChangeDeviceDimmingResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ChangeDeviceDimmingResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ChangeDeviceDimmingResponse proto.InternalMessageInfo
-
-type TurnDeviceOnRequest struct {
-	Id                   int32    `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+func (m *ChangeDevicePositioningResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ChangeDevicePositioningResponse.DiscardUnknown(m)
 }
 
-func (m *TurnDeviceOnRequest) Reset()         { *m = TurnDeviceOnRequest{} }
-func (m *TurnDeviceOnRequest) String() string { return proto.CompactTextString(m) }
-func (*TurnDeviceOnRequest) ProtoMessage()    {}
-func (*TurnDeviceOnRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7f669820b67678c6, []int{17}
-}
-
-func (m *TurnDeviceOnRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_TurnDeviceOnRequest.Unmarshal(m, b)
-}
-func (m *TurnDeviceOnRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_TurnDeviceOnRequest.Marshal(b, m, deterministic)
-}
-func (m *TurnDeviceOnRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TurnDeviceOnRequest.Merge(m, src)
-}
-func (m *TurnDeviceOnRequest) XXX_Size() int {
-	return xxx_messageInfo_TurnDeviceOnRequest.Size(m)
-}
-func (m *TurnDeviceOnRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_TurnDeviceOnRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_TurnDeviceOnRequest proto.InternalMessageInfo
-
-func (m *TurnDeviceOnRequest) GetId() int32 {
-	if m != nil {
-		return m.Id
-	}
-	return 0
-}
-
-type TurnDeviceOnResponse struct {
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *TurnDeviceOnResponse) Reset()         { *m = TurnDeviceOnResponse{} }
-func (m *TurnDeviceOnResponse) String() string { return proto.CompactTextString(m) }
-func (*TurnDeviceOnResponse) ProtoMessage()    {}
-func (*TurnDeviceOnResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7f669820b67678c6, []int{18}
-}
-
-func (m *TurnDeviceOnResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_TurnDeviceOnResponse.Unmarshal(m, b)
-}
-func (m *TurnDeviceOnResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_TurnDeviceOnResponse.Marshal(b, m, deterministic)
-}
-func (m *TurnDeviceOnResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TurnDeviceOnResponse.Merge(m, src)
-}
-func (m *TurnDeviceOnResponse) XXX_Size() int {
-	return xxx_messageInfo_TurnDeviceOnResponse.Size(m)
-}
-func (m *TurnDeviceOnResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_TurnDeviceOnResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_TurnDeviceOnResponse proto.InternalMessageInfo
-
-type TurnDeviceOffRequest struct {
-	Id                   int32    `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *TurnDeviceOffRequest) Reset()         { *m = TurnDeviceOffRequest{} }
-func (m *TurnDeviceOffRequest) String() string { return proto.CompactTextString(m) }
-func (*TurnDeviceOffRequest) ProtoMessage()    {}
-func (*TurnDeviceOffRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7f669820b67678c6, []int{19}
-}
-
-func (m *TurnDeviceOffRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_TurnDeviceOffRequest.Unmarshal(m, b)
-}
-func (m *TurnDeviceOffRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_TurnDeviceOffRequest.Marshal(b, m, deterministic)
-}
-func (m *TurnDeviceOffRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TurnDeviceOffRequest.Merge(m, src)
-}
-func (m *TurnDeviceOffRequest) XXX_Size() int {
-	return xxx_messageInfo_TurnDeviceOffRequest.Size(m)
-}
-func (m *TurnDeviceOffRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_TurnDeviceOffRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_TurnDeviceOffRequest proto.InternalMessageInfo
-
-func (m *TurnDeviceOffRequest) GetId() int32 {
-	if m != nil {
-		return m.Id
-	}
-	return 0
-}
-
-type TurnDeviceOffResponse struct {
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *TurnDeviceOffResponse) Reset()         { *m = TurnDeviceOffResponse{} }
-func (m *TurnDeviceOffResponse) String() string { return proto.CompactTextString(m) }
-func (*TurnDeviceOffResponse) ProtoMessage()    {}
-func (*TurnDeviceOffResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_7f669820b67678c6, []int{20}
-}
-
-func (m *TurnDeviceOffResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_TurnDeviceOffResponse.Unmarshal(m, b)
-}
-func (m *TurnDeviceOffResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_TurnDeviceOffResponse.Marshal(b, m, deterministic)
-}
-func (m *TurnDeviceOffResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TurnDeviceOffResponse.Merge(m, src)
-}
-func (m *TurnDeviceOffResponse) XXX_Size() int {
-	return xxx_messageInfo_TurnDeviceOffResponse.Size(m)
-}
-func (m *TurnDeviceOffResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_TurnDeviceOffResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_TurnDeviceOffResponse proto.InternalMessageInfo
+var xxx_messageInfo_ChangeDevicePositioningResponse proto.InternalMessageInfo
 
 func init() {
 	proto.RegisterType((*DeviceMetadata)(nil), "grpc_server.DeviceMetadata")
@@ -935,14 +669,8 @@ func init() {
 	proto.RegisterType((*ListDeviceIDsResponse)(nil), "grpc_server.ListDeviceIDsResponse")
 	proto.RegisterType((*GetDeviceRequest)(nil), "grpc_server.GetDeviceRequest")
 	proto.RegisterType((*GetDeviceResponse)(nil), "grpc_server.GetDeviceResponse")
-	proto.RegisterType((*ChangeDeviceColorRequest)(nil), "grpc_server.ChangeDeviceColorRequest")
-	proto.RegisterType((*ChangeDeviceColorResponse)(nil), "grpc_server.ChangeDeviceColorResponse")
-	proto.RegisterType((*ChangeDeviceDimmingRequest)(nil), "grpc_server.ChangeDeviceDimmingRequest")
-	proto.RegisterType((*ChangeDeviceDimmingResponse)(nil), "grpc_server.ChangeDeviceDimmingResponse")
-	proto.RegisterType((*TurnDeviceOnRequest)(nil), "grpc_server.TurnDeviceOnRequest")
-	proto.RegisterType((*TurnDeviceOnResponse)(nil), "grpc_server.TurnDeviceOnResponse")
-	proto.RegisterType((*TurnDeviceOffRequest)(nil), "grpc_server.TurnDeviceOffRequest")
-	proto.RegisterType((*TurnDeviceOffResponse)(nil), "grpc_server.TurnDeviceOffResponse")
+	proto.RegisterType((*ChangeDevicePositioningRequest)(nil), "grpc_server.ChangeDevicePositioningRequest")
+	proto.RegisterType((*ChangeDevicePositioningResponse)(nil), "grpc_server.ChangeDevicePositioningResponse")
 }
 
 func init() { proto.RegisterFile("tradfri.proto", fileDescriptor_7f669820b67678c6) }
@@ -1012,10 +740,7 @@ type TradfriServiceClient interface {
 	ListDevices(ctx context.Context, in *ListDevicesRequest, opts ...grpc.CallOption) (*ListDevicesResponse, error)
 	ListDeviceIDs(ctx context.Context, in *ListDeviceIDsRequest, opts ...grpc.CallOption) (*ListDeviceIDsResponse, error)
 	GetDevice(ctx context.Context, in *GetDeviceRequest, opts ...grpc.CallOption) (*GetDeviceResponse, error)
-	ChangeDeviceColor(ctx context.Context, in *ChangeDeviceColorRequest, opts ...grpc.CallOption) (*ChangeDeviceColorResponse, error)
-	ChangeDeviceDimming(ctx context.Context, in *ChangeDeviceDimmingRequest, opts ...grpc.CallOption) (*ChangeDeviceDimmingResponse, error)
-	TurnDeviceOn(ctx context.Context, in *TurnDeviceOnRequest, opts ...grpc.CallOption) (*TurnDeviceOnResponse, error)
-	TurnDeviceOff(ctx context.Context, in *TurnDeviceOffRequest, opts ...grpc.CallOption) (*TurnDeviceOffResponse, error)
+	ChangeDevicePositioning(ctx context.Context, in *ChangeDevicePositioningRequest, opts ...grpc.CallOption) (*ChangeDevicePositioningResponse, error)
 }
 
 type tradfriServiceClient struct {
@@ -1071,36 +796,9 @@ func (c *tradfriServiceClient) GetDevice(ctx context.Context, in *GetDeviceReque
 	return out, nil
 }
 
-func (c *tradfriServiceClient) ChangeDeviceColor(ctx context.Context, in *ChangeDeviceColorRequest, opts ...grpc.CallOption) (*ChangeDeviceColorResponse, error) {
-	out := new(ChangeDeviceColorResponse)
-	err := c.cc.Invoke(ctx, "/grpc_server.TradfriService/ChangeDeviceColor", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *tradfriServiceClient) ChangeDeviceDimming(ctx context.Context, in *ChangeDeviceDimmingRequest, opts ...grpc.CallOption) (*ChangeDeviceDimmingResponse, error) {
-	out := new(ChangeDeviceDimmingResponse)
-	err := c.cc.Invoke(ctx, "/grpc_server.TradfriService/ChangeDeviceDimming", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *tradfriServiceClient) TurnDeviceOn(ctx context.Context, in *TurnDeviceOnRequest, opts ...grpc.CallOption) (*TurnDeviceOnResponse, error) {
-	out := new(TurnDeviceOnResponse)
-	err := c.cc.Invoke(ctx, "/grpc_server.TradfriService/TurnDeviceOn", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *tradfriServiceClient) TurnDeviceOff(ctx context.Context, in *TurnDeviceOffRequest, opts ...grpc.CallOption) (*TurnDeviceOffResponse, error) {
-	out := new(TurnDeviceOffResponse)
-	err := c.cc.Invoke(ctx, "/grpc_server.TradfriService/TurnDeviceOff", in, out, opts...)
+func (c *tradfriServiceClient) ChangeDevicePositioning(ctx context.Context, in *ChangeDevicePositioningRequest, opts ...grpc.CallOption) (*ChangeDevicePositioningResponse, error) {
+	out := new(ChangeDevicePositioningResponse)
+	err := c.cc.Invoke(ctx, "/grpc_server.TradfriService/ChangeDevicePositioning", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1114,10 +812,7 @@ type TradfriServiceServer interface {
 	ListDevices(context.Context, *ListDevicesRequest) (*ListDevicesResponse, error)
 	ListDeviceIDs(context.Context, *ListDeviceIDsRequest) (*ListDeviceIDsResponse, error)
 	GetDevice(context.Context, *GetDeviceRequest) (*GetDeviceResponse, error)
-	ChangeDeviceColor(context.Context, *ChangeDeviceColorRequest) (*ChangeDeviceColorResponse, error)
-	ChangeDeviceDimming(context.Context, *ChangeDeviceDimmingRequest) (*ChangeDeviceDimmingResponse, error)
-	TurnDeviceOn(context.Context, *TurnDeviceOnRequest) (*TurnDeviceOnResponse, error)
-	TurnDeviceOff(context.Context, *TurnDeviceOffRequest) (*TurnDeviceOffResponse, error)
+	ChangeDevicePositioning(context.Context, *ChangeDevicePositioningRequest) (*ChangeDevicePositioningResponse, error)
 }
 
 func RegisterTradfriServiceServer(s *grpc.Server, srv TradfriServiceServer) {
@@ -1214,74 +909,20 @@ func _TradfriService_GetDevice_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
-func _TradfriService_ChangeDeviceColor_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ChangeDeviceColorRequest)
+func _TradfriService_ChangeDevicePositioning_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ChangeDevicePositioningRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(TradfriServiceServer).ChangeDeviceColor(ctx, in)
+		return srv.(TradfriServiceServer).ChangeDevicePositioning(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc_server.TradfriService/ChangeDeviceColor",
+		FullMethod: "/grpc_server.TradfriService/ChangeDevicePositioning",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TradfriServiceServer).ChangeDeviceColor(ctx, req.(*ChangeDeviceColorRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _TradfriService_ChangeDeviceDimming_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ChangeDeviceDimmingRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(TradfriServiceServer).ChangeDeviceDimming(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/grpc_server.TradfriService/ChangeDeviceDimming",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TradfriServiceServer).ChangeDeviceDimming(ctx, req.(*ChangeDeviceDimmingRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _TradfriService_TurnDeviceOn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(TurnDeviceOnRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(TradfriServiceServer).TurnDeviceOn(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/grpc_server.TradfriService/TurnDeviceOn",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TradfriServiceServer).TurnDeviceOn(ctx, req.(*TurnDeviceOnRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _TradfriService_TurnDeviceOff_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(TurnDeviceOffRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(TradfriServiceServer).TurnDeviceOff(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/grpc_server.TradfriService/TurnDeviceOff",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(TradfriServiceServer).TurnDeviceOff(ctx, req.(*TurnDeviceOffRequest))
+		return srv.(TradfriServiceServer).ChangeDevicePositioning(ctx, req.(*ChangeDevicePositioningRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1311,20 +952,8 @@ var _TradfriService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _TradfriService_GetDevice_Handler,
 		},
 		{
-			MethodName: "ChangeDeviceColor",
-			Handler:    _TradfriService_ChangeDeviceColor_Handler,
-		},
-		{
-			MethodName: "ChangeDeviceDimming",
-			Handler:    _TradfriService_ChangeDeviceDimming_Handler,
-		},
-		{
-			MethodName: "TurnDeviceOn",
-			Handler:    _TradfriService_TurnDeviceOn_Handler,
-		},
-		{
-			MethodName: "TurnDeviceOff",
-			Handler:    _TradfriService_TurnDeviceOff_Handler,
+			MethodName: "ChangeDevicePositioning",
+			Handler:    _TradfriService_ChangeDevicePositioning_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/grpc_server/server.go
+++ b/grpc_server/server.go
@@ -100,50 +100,12 @@ func (s *server) GetDevice(ctx context.Context, r *pb.GetDeviceRequest) (*pb.Get
 	}, nil
 }
 
-func (s *server) ChangeDeviceColor(ctx context.Context, r *pb.ChangeDeviceColorRequest) (*pb.ChangeDeviceColorResponse, error) {
+func (s *server) ChangeDevicePositioning(ctx context.Context, r *pb.ChangeDevicePositioningRequest) (*pb.ChangeDevicePositioningResponse, error) {
 	if r.GetId() < 1 {
 		return nil, status.Error(codes.InvalidArgument, "id is mandatory")
 	}
-	// rgb
-	if r.GetRgb() != "" {
-		if _, err := s.tradfriClient.PutDeviceColorRGB(fmt.Sprintf("%d", r.GetId()), r.GetRgb()); err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-		return &pb.ChangeDeviceColorResponse{}, nil
-	}
-	// we assume it is x and y request
-	if _, err := s.tradfriClient.PutDeviceColor(fmt.Sprintf("%d", r.GetId()), int(r.GetXcolor()), int(r.GetYcolor())); err != nil {
+	if _, err := s.tradfriClient.PutDevicePositioning(fmt.Sprintf("%d", r.GetId()), float32(r.GetValue())); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	return &pb.ChangeDeviceColorResponse{}, nil
-}
-
-func (s *server) ChangeDeviceDimming(ctx context.Context, r *pb.ChangeDeviceDimmingRequest) (*pb.ChangeDeviceDimmingResponse, error) {
-	if r.GetId() < 1 {
-		return nil, status.Error(codes.InvalidArgument, "id is mandatory")
-	}
-	if _, err := s.tradfriClient.PutDeviceDimming(fmt.Sprintf("%d", r.GetId()), int(r.GetValue())); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	return &pb.ChangeDeviceDimmingResponse{}, nil
-}
-
-func (s *server) TurnDeviceOn(ctx context.Context, r *pb.TurnDeviceOnRequest) (*pb.TurnDeviceOnResponse, error) {
-	if r.GetId() < 1 {
-		return nil, status.Error(codes.InvalidArgument, "id is mandatory")
-	}
-	if _, err := s.tradfriClient.PutDevicePower(fmt.Sprintf("%d", r.GetId()), 1); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	return &pb.TurnDeviceOnResponse{}, nil
-}
-
-func (s *server) TurnDeviceOff(ctx context.Context, r *pb.TurnDeviceOffRequest) (*pb.TurnDeviceOffResponse, error) {
-	if r.GetId() < 1 {
-		return nil, status.Error(codes.InvalidArgument, "id is mandatory")
-	}
-	if _, err := s.tradfriClient.PutDevicePower(fmt.Sprintf("%d", r.GetId()), 0); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	return &pb.TurnDeviceOffResponse{}, nil
+	return &pb.ChangeDevicePositioningResponse{}, nil
 }

--- a/grpc_server/tradfri.proto
+++ b/grpc_server/tradfri.proto
@@ -11,10 +11,7 @@ service TradfriService {
   rpc ListDeviceIDs (ListDeviceIDsRequest) returns (ListDeviceIDsResponse) {}
 
   rpc GetDevice (GetDeviceRequest) returns (GetDeviceResponse) {}
-  rpc ChangeDeviceColor (ChangeDeviceColorRequest) returns (ChangeDeviceColorResponse) {}
-  rpc ChangeDeviceDimming (ChangeDeviceDimmingRequest) returns (ChangeDeviceDimmingResponse) {}
-  rpc TurnDeviceOn (TurnDeviceOnRequest) returns (TurnDeviceOnResponse) {}
-  rpc TurnDeviceOff (TurnDeviceOffRequest) returns (TurnDeviceOffResponse) {}
+  rpc ChangeDevicePositioning (ChangeDevicePositioningRequest) returns (ChangeDevicePositioningResponse) {}
 }
 
 message DeviceMetadata {
@@ -22,20 +19,16 @@ message DeviceMetadata {
   string name = 2;
   string vendor = 3;
   string type = 4;
+  int32  bat = 10;
 }
 
 message Device{
   DeviceMetadata metadata = 1;
-  int32 dimmer = 2;
-  int32 xcolor = 3;
-  int32 ycolor = 4;
-  string rgb = 5;
-  bool power = 6;
+  float position = 2;
 }
 
 message Group{
   int32 id = 1;
-  int32 power = 2;
   string created = 3;
   repeated int32 devices = 4;
 }
@@ -78,30 +71,9 @@ message GetDeviceResponse{
   Device device = 1;
 }
 
-message ChangeDeviceColorRequest{
-  int32 id = 1;
-  int32 xcolor = 2;
-  int32 ycolor = 3;
-  string rgb = 4;
-}
-
-message ChangeDeviceColorResponse{}
-
-message ChangeDeviceDimmingRequest{
+message ChangeDevicePositioningRequest{
   int32 id = 1;
   int32 value = 2;
 }
 
-message ChangeDeviceDimmingResponse{}
-
-message TurnDeviceOnRequest{
-  int32 id = 1;
-}
-
-message TurnDeviceOnResponse{}
-
-message TurnDeviceOffRequest{
-  int32 id = 1;
-}
-
-message TurnDeviceOffResponse{}
+message ChangeDevicePositioningResponse{}

--- a/main.go
+++ b/main.go
@@ -22,24 +22,24 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-var configFlags = pflag.NewFlagSet("config", pflag.ExitOnError)
+var configFlags  = pflag.NewFlagSet("config",   pflag.ExitOnError)
 var commandFlags = pflag.NewFlagSet("commands", pflag.ExitOnError)
 
 func init() {
 
-	configFlags.String("gateway_ip", "", "ip to your gateway. No protocol or port here!")
-	configFlags.String("gateway_address", "", "address to your gateway. Including port here!")
-	configFlags.String("psk", "", "Pre-shared key on bottom of Gateway")
-	configFlags.String("client_id", "", "Your client id, make something up or use the NNN-NNN-NNN on the bottom of your Gateway")
-	configFlags.String("loglevel", "info", "log leve. Allowed values: fatal, error, warn, info, debug, trace")
+	configFlags.String("gateway_ip",      "",     "ip to your gateway. No protocol or port here!")
+	configFlags.String("gateway_address", "",     "address to your gateway. Including port here!")
+	configFlags.String("psk",             "",     "Pre-shared key on bottom of Gateway")
+	configFlags.String("client_id",       "",     "Your client id, make something up or use the NNN-NNN-NNN on the bottom of your Gateway")
+	configFlags.String("loglevel",        "info", "log leve. Allowed values: fatal, error, warn, info, debug, trace")
 
-	commandFlags.Bool("server", false, "Start in server mode?")
-	commandFlags.Bool("authenticate", false, "Perform PSK exchange")
-	commandFlags.String("get", "", "URL to GET")
-	commandFlags.String("put", "", "URL to PUT")
-	commandFlags.String("payload", "", "payload for PUT")
-	commandFlags.Int("port", 8080, "port of the server")
-	commandFlags.Int("grpc_port", 8081, "port of the grpc server")
+	commandFlags.Bool("server",           false,  "Start in server mode?")
+	commandFlags.Bool("authenticate",     false,  "Perform PSK exchange")
+	commandFlags.String("get",            "",     "URL to GET")
+	commandFlags.String("put",            "",     "URL to PUT")
+	commandFlags.String("payload",        "",     "payload for PUT")
+	commandFlags.Int("port",              80,     "port of the server")
+	commandFlags.Int("grpc_port",         81,     "port of the grpc server")
 
 	commandFlags.AddFlagSet(configFlags)
 	commandFlags.Parse(os.Args[1:])
@@ -90,15 +90,15 @@ func main() {
 	if gatewayAddress == "" {
 		gatewayAddress = viper.GetString("gateway_ip") + ":5684"
 	}
-	psk := viper.GetString("psk")
-	clientID := viper.GetString("client_id")
-	serverMode, _ := commandFlags.GetBool("server")
+	psk             := viper.GetString("psk")
+	clientID        := viper.GetString("client_id")
+	serverMode, _   := commandFlags.GetBool("server")
 	authenticate, _ := commandFlags.GetBool("authenticate")
-	get, getErr := commandFlags.GetString("get")
-	put, putErr := commandFlags.GetString("put")
-	payload, _ := commandFlags.GetString("payload")
-	port, _ := commandFlags.GetInt("port")
-	grpcPort, _ := commandFlags.GetInt("grpc_port")
+	get, getErr     := commandFlags.GetString("get")
+	put, putErr     := commandFlags.GetString("put")
+	payload, _      := commandFlags.GetString("payload")
+	port, _         := commandFlags.GetInt("port")
+	grpcPort, _     := commandFlags.GetInt("grpc_port")
 
 	// Handle the special authenticate use-case
 	if authenticate {
@@ -173,9 +173,9 @@ func performTokenExchange(gatewayAddress, clientID, psk string) {
 	if err != nil {
 		fail(err.Error())
 	}
-	viper.Set("client_id", clientID)
+	viper.Set("client_id",       clientID)
 	viper.Set("gateway_address", gatewayAddress)
-	viper.Set("psk", authToken.Token)
+	viper.Set("psk",             authToken.Token)
 	err = viper.WriteConfigAs("config.json")
 	if err != nil {
 		fail(err.Error())

--- a/model/mapper.go
+++ b/model/mapper.go
@@ -5,40 +5,35 @@ import (
 	"time"
 )
 
-func ToDeviceResponse(device Device) BulbResponse {
-	if device.LightControl != nil && len(device.LightControl) > 0 {
+func ToDeviceResponse(device Device) BlindResponse {
+	if device.BlindControl != nil && len(device.BlindControl) > 0 {
 
-		dr := BulbResponse{
-			DeviceMetadata: DeviceMetadata{
-				Name:   device.Name,
-				Id:     device.DeviceId,
-				Type:   device.Metadata.TypeName,
-				Vendor: device.Metadata.Vendor},
-			Power:      device.LightControl[0].Power == 1,
-			CIE_1931_X: device.LightControl[0].CIE_1931_X,
-			CIE_1931_Y: device.LightControl[0].CIE_1931_Y,
-			RGB:        device.LightControl[0].RGBHex,
-			Dimmer:     device.LightControl[0].Dimmer,
+		dr := BlindResponse{
+			DeviceMetadata:  DeviceMetadata{
+				Name:    device.Name,
+				Id:      device.DeviceId,
+				Type:    device.Metadata.TypeName,
+				Vendor:  device.Metadata.Vendor,
+				Battery: device.Metadata.Battery,
+			},
+			Position: device.BlindControl[0].Position,
 		}
 		return dr
 	}
-	return BulbResponse{}
+	return BlindResponse{}
 }
 
 func ToDeviceResponseProto(device Device) *pb.Device {
-	if device.LightControl != nil && len(device.LightControl) > 0 {
+	if device.BlindControl != nil && len(device.BlindControl) > 0 {
 		return &pb.Device{
 			Metadata: &pb.DeviceMetadata{
-				Name:   device.Name,
-				Id:     int32(device.DeviceId),
-				Type:   device.Metadata.TypeName,
-				Vendor: device.Metadata.Vendor,
+				Name:    device.Name,
+				Id:      int32(device.DeviceId),
+				Type:    device.Metadata.TypeName,
+				Vendor:  device.Metadata.Vendor,
+				Battery: int(device.Metadata.Battery),
 			},
-			Power:  device.LightControl[0].Power == 1,
-			Xcolor: int32(device.LightControl[0].CIE_1931_X),
-			Ycolor: int32(device.LightControl[0].CIE_1931_Y),
-			Rgb:    device.LightControl[0].RGBHex,
-			Dimmer: int32(device.LightControl[0].Dimmer),
+			Position: float32(device.BlindControl[0].Position),
 		}
 	}
 	return &pb.Device{}
@@ -47,7 +42,6 @@ func ToDeviceResponseProto(device Device) *pb.Device {
 func ToGroupResponse(group Group) GroupResponse {
 	gr := GroupResponse{
 		Id:         group.DeviceId,
-		Power:      group.Power,
 		Created:    time.Unix(int64(group.Num9002), 0).Format(time.RFC3339),
 		DeviceList: group.Content.DeviceList.DeviceIds,
 	}
@@ -61,7 +55,6 @@ func ToGroupResponseProto(group Group) *pb.Group {
 	}
 	return &pb.Group{
 		Id:      int32(group.DeviceId),
-		Power:   int32(group.Power),
 		Created: time.Unix(int64(group.Num9002), 0).Format(time.RFC3339),
 		Devices: ids,
 	}

--- a/model/models.go
+++ b/model/models.go
@@ -8,17 +8,12 @@ type Device struct {
 		Num2     string `json:"2"`
 		TypeId   string `json:"3"`
 		Num6     int    `json:"6"`
+		Battery  int    `json:"9"`
 	} `json:"3"`
-	LightControl []struct {
-		RGBHex     string `json:"5706"`
-		Num5707    int    `json:"5707"`
-		Num5708    int    `json:"5708"`
-		CIE_1931_X int    `json:"5709"`
-		CIE_1931_Y int    `json:"5710"`
-		Power      int    `json:"5850"`
-		Dimmer     int    `json:"5851"`
-		Num9003    int    `json:"9003"`
-	} `json:"3311"`
+	BlindControl []struct {
+		Position float32 `json:"5536"`
+		Num9003  int     `json:"9003"`
+	} `json:"15015"`
 	Num5750  int    `json:"5750"`
 	Name     string `json:"9001"`
 	Num9002  int    `json:"9002"`
@@ -30,7 +25,6 @@ type Device struct {
 
 // Group defines (with JSON tags) a IKEA trådfri Group.
 type Group struct {
-	Power    int    `json:"5850"`
 	Num5851  int    `json:"5851"`
 	Name     string `json:"9001"`
 	Num9002  int    `json:"9002"`
@@ -44,74 +38,19 @@ type Group struct {
 	Num9108 int `json:"9108"`
 }
 
-// RemoteControl defines (with JSON tags) a IKEA remote control.
-type RemoteControl struct {
-	Metadata struct {
-		Num0 string `json:"0"`
-		Num1 string `json:"1"`
-		Num2 string `json:"2"`
-		Num3 string `json:"3"`
-		Num6 int    `json:"6"`
-		Num9 int    `json:"9"`
-	} `json:"3"`
-	Num5750  int    `json:"5750"`
-	Num9001  string `json:"9001"`
-	Num9002  int    `json:"9002"`
-	Num9003  int    `json:"9003"`
-	Num9019  int    `json:"9019"`
-	Num9020  int    `json:"9020"`
-	Num9054  int    `json:"9054"`
-	Num15009 []struct {
-		Num9003 int `json:"9003"`
-	} `json:"15009"`
-}
-
-// ControlOutlet defines (with JSON tags) a IKEA control outlet.
-type ControlOutlet struct {
-	Metadata struct {
-		Num0 string `json:"0"`
-		Num1 string `json:"1"`
-		Num2 string `json:"2"`
-		Num3 string `json:"3"`
-		Num6 int    `json:"6"`
-	} `json:"3"`
-	PowerControl []struct {
-		Num5850 int `json:"5850"`
-		Num5851 int `json:"5851"`
-		Num9003 int `json:"9003"`
-	} `json:"3312"`
-	Num5750 int    `json:"5750"`
-	Num9001 string `json:"9001"`
-	Num9002 int    `json:"9002"`
-	Num9003 int    `json:"9003"`
-	Num9019 int    `json:"9019"`
-	Num9020 int    `json:"9020"`
-	Num9054 int    `json:"9054"`
-	Num9084 string `json:"9084"`
-}
-
 // DeviceMetadata defines (with JSON tags) common device metadata. Typically embedded in other structs.
 type DeviceMetadata struct {
-	Id     int    `json:"id"`
-	Name   string `json:"name"`
-	Vendor string `json:"vendor"`
-	Type   string `json:"type"`
+	Id      int    `json:"id"`
+	Name    string `json:"name"`
+	Vendor  string `json:"vendor"`
+	Type    string `json:"type"`
+	Battery int    `json:"battery"`
 }
 
-// PowerPlugResponse is the response from a power plug device GET.
-type PowerPlugResponse struct {
+// BlindResponse is the response from a bild GET.
+type BlindResponse struct {
 	DeviceMetadata DeviceMetadata `json:"deviceMetadata"`
-	Power          bool           `json:"power"`
-}
-
-// BulbResponse is the response from a light bulb GET.
-type BulbResponse struct {
-	DeviceMetadata DeviceMetadata `json:"deviceMetadata"`
-	Dimmer         int            `json:"dimmer"`
-	CIE_1931_X     int            `json:"xcolor"`
-	CIE_1931_Y     int            `json:"ycolor"`
-	RGB            string         `json:"rgbcolor"`
-	Power          bool           `json:"power"`
+	Position float32 `json:"position"`
 }
 
 type Result struct {
@@ -126,29 +65,11 @@ type TokenExchange struct {
 // REST API structs
 type GroupResponse struct {
 	Id         int    `json:"id"`
-	Power      int    `json:"power"`
 	Created    string `json:"created"`
 	DeviceList []int  `json:"deviceList"`
 }
 
-// RgbColorRequest allows (trying to) set a bulb color using classic hex RGB string.
-type RgbColorRequest struct {
-	RGBcolor string `json:"rgbcolor"`
-}
-
-// DimmingRequest allows setting the dimmer level from 0-255.
-type DimmingRequest struct {
-	Dimming int `json:"dimming"`
-}
-
-// PowerRequest contains a Power state int, 1 == on, 0 == off.
-type PowerRequest struct {
-	Power int `json:"power"`
-}
-
-// StateRequest allows setting both color, dimmer and power setting in a single PUT.
-type StateRequest struct {
-	RGBcolor string `json:"rgbcolor"`
-	Dimmer   int    `json:"dimmer"`
-	Power    int    `json:"power"`
+// PositioningRequest allows setting the position from 0-100.
+type PositioningRequest struct {
+	Positioning float32 `json:"positioning"`
 }

--- a/router/router.go
+++ b/router/router.go
@@ -19,13 +19,11 @@ var tradfriClient *tradfri.Client
 // SetupChi sets up our HTTP router/muxer using Chi, a pointer to a Client must be passed.
 func SetupChi(client *tradfri.Client, port int) {
 	tradfriClient = client
-	logger := middleware.RequestLogger(&middleware.DefaultLogFormatter{Logger: logrus.StandardLogger(), NoColor: false})
 	r := chi.NewRouter()
 
 	// A good base middleware stack
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
-	r.Use(logger)
 	r.Use(middleware.Recoverer)
 
 	// Set a timeout value on the request context (ctx), that will signal
@@ -44,11 +42,7 @@ func SetupChi(client *tradfri.Client, port int) {
 		r.Get("/groups/{groupId}/deviceIds", getDeviceIdsOnGroup)
 		r.Get("/groups/{groupId}/devices", getDevicesOnGroup)
 		r.Get("/device/{deviceId}", getDevice)
-		r.Put("/device/{deviceId}/color", setColorXY)
-		r.Put("/device/{deviceId}/rgb", setColorRGBHex)
-		r.Put("/device/{deviceId}/dimmer", setDimming)
-		r.Put("/device/{deviceId}/power", setPower)
-		r.Put("/device/{deviceId}", setState)
+		r.Put("/device/{deviceId}/position", setPositioning)
 
 	})
 
@@ -56,65 +50,16 @@ func SetupChi(client *tradfri.Client, port int) {
 	http.ListenAndServe(fmt.Sprintf(":%d", port), r)
 }
 
-func setColorXY(w http.ResponseWriter, r *http.Request) {
-	deviceId := chi.URLParam(r, "deviceId")
-	xStr := chi.URLParam(r, "x")
-	yStr := chi.URLParam(r, "y")
-	x, _ := strconv.Atoi(xStr)
-	y, _ := strconv.Atoi(yStr)
-	res, err := tradfriClient.PutDeviceColor(deviceId, x, y)
-	respond(w, res, err)
-}
-
-func setColorRGBHex(w http.ResponseWriter, r *http.Request) {
+func setPositioning(w http.ResponseWriter, r *http.Request) {
 	deviceId := chi.URLParam(r, "deviceId")
 	body, _ := ioutil.ReadAll(r.Body)
 
-	rgbColorRequest := model.RgbColorRequest{}
-	if err := json.Unmarshal(body, &rgbColorRequest); err != nil {
+	positioningRequest := model.PositioningRequest{}
+	if err := json.Unmarshal(body, &positioningRequest); err != nil {
 		badRequest(w, err)
 		return
 	}
-	result, err := tradfriClient.PutDeviceColorRGB(deviceId, rgbColorRequest.RGBcolor)
-	respond(w, result, err)
-}
-
-func setDimming(w http.ResponseWriter, r *http.Request) {
-	deviceId := chi.URLParam(r, "deviceId")
-	body, _ := ioutil.ReadAll(r.Body)
-
-	dimmingRequest := model.DimmingRequest{}
-	if err := json.Unmarshal(body, &dimmingRequest); err != nil {
-		badRequest(w, err)
-		return
-	}
-	res, err := tradfriClient.PutDeviceDimming(deviceId, dimmingRequest.Dimming)
-	respond(w, res, err)
-}
-
-func setPower(w http.ResponseWriter, r *http.Request) {
-	deviceId := chi.URLParam(r, "deviceId")
-	body, _ := ioutil.ReadAll(r.Body)
-
-	powerRequest := model.PowerRequest{}
-	if err := json.Unmarshal(body, &powerRequest); err != nil {
-		badRequest(w, err)
-		return
-	}
-	res, err := tradfriClient.PutDevicePower(deviceId, powerRequest.Power)
-	respond(w, res, err)
-}
-
-func setState(w http.ResponseWriter, r *http.Request) {
-	deviceId := chi.URLParam(r, "deviceId")
-	body, _ := ioutil.ReadAll(r.Body)
-
-	stateReq := model.StateRequest{}
-	if err := json.Unmarshal(body, &stateReq); err != nil {
-		badRequest(w, err)
-		return
-	}
-	res, err := tradfriClient.PutDeviceState(deviceId, stateReq.Power, stateReq.Dimmer, stateReq.RGBcolor)
+	res, err := tradfriClient.PutDevicePositioning(deviceId, positioningRequest.Positioning)
 	respond(w, res, err)
 }
 
@@ -134,7 +79,7 @@ func getGroup(w http.ResponseWriter, r *http.Request) {
 
 func getDevicesOnGroup(w http.ResponseWriter, r *http.Request) {
 	group, _ := tradfriClient.GetGroup(chi.URLParam(r, "groupId"))
-	devices := make([]model.BulbResponse, 0)
+	devices := make([]model.BlindResponse, 0)
 	for _, deviceID := range group.Content.DeviceList.DeviceIds {
 		device, _ := tradfriClient.GetDevice(strconv.Itoa(deviceID))
 		devices = append(devices, model.ToDeviceResponse(device))

--- a/tradfri/tradfri-client.go
+++ b/tradfri/tradfri-client.go
@@ -23,66 +23,9 @@ func NewTradfriClient(gatewayAddress, clientID, psk string) *Client {
 	return client
 }
 
-// PutDeviceDimming sets the dimming property (0-255) of the specified device.
-// The device must be a bulb supporting dimming, otherwise the call if ineffectual.
-func (tc *Client) PutDeviceDimming(deviceId string, dimming int) (model.Result, error) {
-	payload := fmt.Sprintf(`{ "3311": [{ "5851": %d }] }`, dimming)
-	logrus.Infof("Payload is: %v", payload)
-	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
-	if err != nil {
-		return model.Result{}, err
-	}
-	logrus.Infof("Response: %+v", resp)
-	return model.Result{Msg: resp.Code.String()}, nil
-}
-
-// PutDevicePower switches the power state of the specified device to on (1) or off (0)
-func (tc *Client) PutDevicePower(deviceId string, power int) (model.Result, error) {
-	if !(power == 1 || power == 0) {
-		return model.Result{}, fmt.Errorf("invalid value for setting power state, must be 1 or 0")
-	}
-	payload := fmt.Sprintf(`{ "3311": [{ "5850": %d }] }`, power)
-	logrus.Infof("Payload is: %v", payload)
-	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
-	if err != nil {
-		return model.Result{}, err
-	}
-	logrus.Infof("Response: %+v", resp)
-	return model.Result{Msg: resp.Code.String()}, nil
-}
-
-// PutDeviceState allows changing both power (1 or 0) and dimmer (0-255) for a given device with one command.
-func (tc *Client) PutDeviceState(deviceId string, power int, dimmer int, color string) (model.Result, error) {
-	if !(power == 1 || power == 0) {
-		return model.Result{}, fmt.Errorf("invalid value for setting power state, must be 1 or 0")
-	}
-	payload := fmt.Sprintf(`{ "3311": [{ "5850": %d, "5851": %d}] }`, power, dimmer) // , "5706": "%s"
-	logrus.Infof("Payload is: %v", payload)
-	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
-	if err != nil {
-		return model.Result{}, err
-	}
-	logrus.Infof("Response: %+v", resp)
-	return model.Result{Msg: resp.Code.String()}, nil
-}
-
-// PutDeviceColor sets the CIE 1931 color space x/y color, x and y must be between 0-65536 but note that
-// many combinations won't work. See CIE 1931 for more details.
-func (tc *Client) PutDeviceColor(deviceId string, x, y int) (model.Result, error) {
-	payload := fmt.Sprintf(`{ "3311": [ {"5709": %d, "5710": %d}] }`, x, y)
-	logrus.Infof("Payload is: %v", payload)
-	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
-	if err != nil {
-		return model.Result{}, err
-	}
-	logrus.Infof("Response: %+v", resp)
-	return model.Result{Msg: resp.Code.String()}, nil
-}
-
-// PutDeviceColorRGB sets the color of the bulb using RGB hex string such as 8f2686 (purple). Note that
-// many colors doesn't seem to work. Not sure how the IKEA bulbs with color support works.
-func (tc *Client) PutDeviceColorRGB(deviceId, rgb string) (model.Result, error) {
-	payload := fmt.Sprintf(`{ "3311": [ {"5706": "%s"}] }`, rgb)
+// PutDevicePositioning sets the positioning property (0-100) of the specified device.
+func (tc *Client) PutDevicePositioning(deviceId string, positioning float32) (model.Result, error) {
+	payload := fmt.Sprintf(`{ "15015": [{ "5536": %f }] }`, positioning)
 	logrus.Infof("Payload is: %v", payload)
 	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
 	if err != nil {


### PR DESCRIPTION
Hi, This is not really a pull request. I just waned to give something back as I have been using your project to make a tradfri-go-blind-server to manage my Ikea smart blinds.

I don't know if you can use this, and maybe implement blind control in your project :)

I have also added docker components to build it and run the server as a docker container :)

Here are an export from all my devices, maybe it is useful for you as well:

```
[{'15015': [{'5536': 0.0, '9003': 0}],
  '3': {'0': 'IKEA of Sweden',
        '1': 'FYRTUR block-out roller blind',
        '2': '',
        '3': '2.2.009',
        '6': 3,
        '9': 62},
  '5750': 7,
  '9001': 'Right',
  '9002': 1567889303,
  '9003': 65542,
  '9019': 0,
  '9020': 1577379042,
  '9054': 0},
 {'15015': [{'5536': 50.0, '9003': 0}],
  '3': {'0': 'IKEA of Sweden',
        '1': 'FYRTUR block-out roller blind',
        '2': '',
        '3': '2.2.009',
        '6': 3,
        '9': 0},
  '5750': 7,
  '9001': 'Left Blind',
  '9002': 1567863795,
  '9003': 65538,
  '9019': 0,
  '9020': 1580082181,
  '9054': 0},
 {'15009': [{'9003': 0}],
  '3': {'0': '\x02KE',
        '1': 'TRADFRI open/close remote',
        '2': '',
        '3': '2.2.010',
        '6': 3,
        '9': 100},
  '5750': 0,
  '9001': 'TRADFRI open/close remote 2',
  '9002': 1567867466,
  '9003': 65540,
  '9019': 1,
  '9020': 1581279506,
  '9054': 0},
 {'15014': [{'9003': 0}],
  '3': {'0': 'IKEA of Sweden',
        '1': 'TRADFRI signal repeater',
        '2': '',
        '3': '2.2.005',
        '6': 1},
  '5750': 6,
  '9001': 'TRADFRI signal repeater',
  '9002': 1567863721,
  '9003': 65537,
  '9019': 1,
  '9020': 1581259898,
  '9054': 0},
 {'15015': [{'5536': 42.0, '9003': 0}],
  '3': {'0': 'IKEA of Sweden',
        '1': 'FYRTUR block-out roller blind',
        '2': '',
        '3': '2.2.009',
        '6': 3,
        '9': 86},
  '5750': 7,
  '9001': 'Right Blind',
  '9002': 1567863962,
  '9003': 65539,
  '9019': 1,
  '9020': 1581213029,
  '9054': 0},
 {'15009': [{'9003': 0}],
  '3': {'0': '\x02KE',
        '1': 'TRADFRI open/close remote',
        '2': '',
        '3': '2.2.010',
        '6': 3,
        '9': 100},
  '5750': 0,
  '9001': 'TRADFRI open/close remote',
  '9002': 1567863692,
  '9003': 65536,
  '9019': 1,
  '9020': 1581209407,
  '9054': 0},
 {'15015': [{'5536': 20.0, '9003': 0}],
  '3': {'0': 'IKEA of Sweden',
        '1': 'FYRTUR block-out roller blind',
        '2': '',
        '3': '2.2.009',
        '6': 3,
        '9': 90},
  '5750': 7,
  '9001': 'left',
  '9002': 1567868063,
  '9003': 65541,
  '9019': 1,
  '9020': 1581271368,
  '9054': 0}]
```

