### PR TITLE
Correctly name device properties and add function to fetch all devices

### DIFF
--- a/model/mapper.go
+++ b/model/mapper.go
@@ -1,8 +1,9 @@
 package model
 
 import (
-	pb "github.com/eriklupander/tradfri-go/grpc_server/golang"
 	"time"
+
+	pb "github.com/eriklupander/tradfri-go/grpc_server/golang"
 )
 
 // ToDeviceResponse transforms the passed device into either a BulbResponse or BlindResponse. (more needed)
@@ -77,7 +78,7 @@ func ToGroupResponse(group Group) GroupResponse {
 	gr := GroupResponse{
 		Id:         group.DeviceId,
 		Power:      group.Power,
-		Created:    time.Unix(int64(group.Num9002), 0).Format(time.RFC3339),
+		Created:    time.Unix(int64(group.CreatedAt), 0).Format(time.RFC3339),
 		DeviceList: group.Content.DeviceList.DeviceIds,
 	}
 	return gr
@@ -92,7 +93,7 @@ func ToGroupResponseProto(group Group) *pb.Group {
 	return &pb.Group{
 		Id:      int32(group.DeviceId),
 		Power:   int32(group.Power),
-		Created: time.Unix(int64(group.Num9002), 0).Format(time.RFC3339),
+		Created: time.Unix(int64(group.CreatedAt), 0).Format(time.RFC3339),
 		Devices: ids,
 	}
 }

--- a/model/models.go
+++ b/model/models.go
@@ -3,70 +3,70 @@ package model
 // Device defines (with JSON tags) a IKEA trådfri device of some kind
 type Device struct {
 	Metadata struct {
-		Vendor   string `json:"0"`
-		TypeName string `json:"1"`
-		Num2     string `json:"2"`
-		TypeId   string `json:"3"`
-		Num6     int    `json:"6"`
-		Battery  int    `json:"9"`
+		Vendor       string `json:"0"`
+		TypeName     string `json:"1"`
+		SerialNumber string `json:"2"`
+		TypeId       string `json:"3"`
+		PowerType    int    `json:"6"`
+		Battery      int    `json:"9"`
 	} `json:"3"`
 	LightControl []struct {
 		RGBHex     string `json:"5706"`
-		Num5707    int    `json:"5707"`
-		Num5708    int    `json:"5708"`
+		Hue        int    `json:"5707"`
+		Saturation int    `json:"5708"`
 		CIE_1931_X int    `json:"5709"`
 		CIE_1931_Y int    `json:"5710"`
 		Power      int    `json:"5850"`
 		Dimmer     int    `json:"5851"`
-		Num9003    int    `json:"9003"`
+		DeviceId   int    `json:"9003"`
 	} `json:"3311"`
 	BlindControl []struct {
 		Position float32 `json:"5536"`
-		Num9003  int     `json:"9003"`
+		DeviceId int     `json:"9003"`
 	} `json:"15015"`
-	Num5750  int    `json:"5750"`
-	Name     string `json:"9001"`
-	Num9002  int    `json:"9002"`
-	DeviceId int    `json:"9003"`
-	Num9019  int    `json:"9019"`
-	Num9020  int    `json:"9020"`
-	Num9054  int    `json:"9054"`
+	Type           int    `json:"5750"`
+	Name           string `json:"9001"`
+	CreatedAt      int    `json:"9002"`
+	DeviceId       int    `json:"9003"`
+	Alive          int    `json:"9019"`
+	LastSeen       int    `json:"9020"`
+	OtaUpdateState int    `json:"9054"`
 }
 
 // Group defines (with JSON tags) a IKEA trådfri Group.
 type Group struct {
-	Power    int    `json:"5850"`
-	Num5851  int    `json:"5851"`
-	Name     string `json:"9001"`
-	Num9002  int    `json:"9002"`
-	DeviceId int    `json:"9003"`
-	Content  struct {
+	Power     int    `json:"5850"`
+	Dimmer    int    `json:"5851"`
+	Name      string `json:"9001"`
+	CreatedAt int    `json:"9002"`
+	DeviceId  int    `json:"9003"`
+	Content   struct {
 		DeviceList struct {
 			DeviceIds []int `json:"9003"`
 		} `json:"15002"`
 	} `json:"9018"`
-	Num9039 int `json:"9039"`
-	Num9108 int `json:"9108"`
+	SceneId   int `json:"9039"`
+	GroupType int `json:"9108"`
 }
 
 // RemoteControl defines (with JSON tags) a IKEA remote control.
 type RemoteControl struct {
 	Metadata struct {
-		Num0 string `json:"0"`
-		Num1 string `json:"1"`
-		Num2 string `json:"2"`
-		Num3 string `json:"3"`
-		Num6 int    `json:"6"`
-		Num9 int    `json:"9"`
+		Manufacturer    string `json:"0"`
+		ModelNumber     string `json:"1"`
+		SerialNumber    string `json:"2"`
+		FirmwareVersion string `json:"3"`
+		PowerType       int    `json:"6"`
+		Battery         int    `json:"9"`
 	} `json:"3"`
-	Num5750  int    `json:"5750"`
-	Num9001  string `json:"9001"`
-	Num9002  int    `json:"9002"`
-	Num9003  int    `json:"9003"`
-	Num9019  int    `json:"9019"`
-	Num9020  int    `json:"9020"`
-	Num9054  int    `json:"9054"`
-	Num15009 []struct {
+	Type           int    `json:"5750"`
+	Name           string `json:"9001"`
+	CreatedAt      int    `json:"9002"`
+	DeviceId       int    `json:"9003"`
+	Alive          int    `json:"9019"`
+	LastSeen       int    `json:"9020"`
+	OtaUpdateState int    `json:"9054"`
+	SwitchList     []struct {
 		Num9003 int `json:"9003"`
 	} `json:"15009"`
 }
@@ -74,25 +74,25 @@ type RemoteControl struct {
 // ControlOutlet defines (with JSON tags) a IKEA control outlet.
 type ControlOutlet struct {
 	Metadata struct {
-		Num0 string `json:"0"`
-		Num1 string `json:"1"`
-		Num2 string `json:"2"`
-		Num3 string `json:"3"`
-		Num6 int    `json:"6"`
+		Manufacturer    string `json:"0"`
+		ModelNumber     string `json:"1"`
+		SerialNumber    string `json:"2"`
+		FirmwareVersion string `json:"3"`
+		PowerType       int    `json:"6"`
 	} `json:"3"`
 	PowerControl []struct {
-		Num5850 int `json:"5850"`
-		Num5851 int `json:"5851"`
-		Num9003 int `json:"9003"`
+		Power    int `json:"5850"`
+		Dimmer   int `json:"5851"`
+		DeviceId int `json:"9003"`
 	} `json:"3312"`
-	Num5750 int    `json:"5750"`
-	Num9001 string `json:"9001"`
-	Num9002 int    `json:"9002"`
-	Num9003 int    `json:"9003"`
-	Num9019 int    `json:"9019"`
-	Num9020 int    `json:"9020"`
-	Num9054 int    `json:"9054"`
-	Num9084 string `json:"9084"`
+	Type           int    `json:"5750"`
+	Name           string `json:"9001"`
+	CreatedAt      int    `json:"9002"`
+	DeviceId       int    `json:"9003"`
+	Alive          int    `json:"9019"`
+	LastSeen       int    `json:"9020"`
+	OtaUpdateState int    `json:"9054"`
+	HashUnknown    string `json:"9084"`
 }
 
 // DeviceMetadata defines (with JSON tags) common device metadata. Typically embedded in other structs.

--- a/model/models.go
+++ b/model/models.go
@@ -11,14 +11,16 @@ type Device struct {
 		Battery      int    `json:"9"`
 	} `json:"3"`
 	LightControl []struct {
-		RGBHex     string `json:"5706"`
-		Hue        int    `json:"5707"`
-		Saturation int    `json:"5708"`
-		CIE_1931_X int    `json:"5709"`
-		CIE_1931_Y int    `json:"5710"`
-		Power      int    `json:"5850"`
-		Dimmer     int    `json:"5851"`
-		DeviceId   int    `json:"9003"`
+		RGBHex           string  `json:"5706"`
+		Hue              int     `json:"5707"`
+		Saturation       int     `json:"5708"`
+		CIE_1931_X       int     `json:"5709"`
+		CIE_1931_Y       int     `json:"5710"`
+		ColorTemperature int     `json:"5711"`
+		TransitionTime   float64 `json:"5712"`
+		Power            int     `json:"5850"`
+		Dimmer           int     `json:"5851"`
+		DeviceId         int     `json:"9003"`
 	} `json:"3311"`
 	BlindControl []struct {
 		Position float32 `json:"5536"`

--- a/tradfri/tradfri-client.go
+++ b/tradfri/tradfri-client.go
@@ -98,12 +98,12 @@ func (tc *Client) PutDeviceState(deviceId string, power int, dimmer int, color s
 // many combinations won't work. See CIE 1931 for more details.
 // It is not recommended to use these values to set colors, as it is often not supported by the gateway and is intended for internal use.
 func (tc *Client) PutDeviceColor(deviceId string, x, y int) (model.Result, error) {
-	return tc.PutDeviceColorTimed(deviceId, x, y, 0.5)
+	return tc.PutDeviceColorTimed(deviceId, x, y, 500)
 }
 
 // PutDeviceColorTimed does the same as PutDeviceColor but it gives you the ability to change the speed at which the color changes
-func (tc *Client) PutDeviceColorTimed(deviceId string, x, y int, transitionTime float64) (model.Result, error) {
-	payload := fmt.Sprintf(`{ "3311": [ {"5709": %d, "5710": %d, "5712": %f}] }`, x, y, transitionTime)
+func (tc *Client) PutDeviceColorTimed(deviceId string, x, y int, transitionTimeMS int) (model.Result, error) {
+	payload := fmt.Sprintf(`{ "3311": [ {"5709": %d, "5710": %d, "5712": %d}] }`, x, y, transitionTimeMS/100)
 	logrus.Infof("Payload is: %v", payload)
 	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
 	if err != nil {
@@ -116,44 +116,44 @@ func (tc *Client) PutDeviceColorTimed(deviceId string, x, y int, transitionTime 
 // PutDeviceColorRGB sets the color of the bulb using RGB hex string such as 8f2686 (purple). Note that
 // It does not use the built in rgb hex parameter as that does not work reliably, so the rgb is converted to hsl and that is sent
 func (tc *Client) PutDeviceColorRGB(deviceId, rgb string) (model.Result, error) {
-	return tc.PutDeviceColorRGBTimed(deviceId, rgb, 0.5)
+	return tc.PutDeviceColorRGBTimed(deviceId, rgb, 500)
 }
 
 // PutDeviceColorRGBTimed does the same as PutDeviceColorRGB but it gives you the ability to change the speed at which the color changes
-func (tc *Client) PutDeviceColorRGBTimed(deviceId, rgb string, transitionTime float64) (model.Result, error) {
+func (tc *Client) PutDeviceColorRGBTimed(deviceId, rgb string, transitionTimeMS int) (model.Result, error) {
 	r, g, b, err := hexStringToRgb(rgb)
 	if err != nil {
 		return model.Result{}, err
 	}
 
-	return tc.PutDeviceColorRGBIntTimed(deviceId, r, g, b, transitionTime)
+	return tc.PutDeviceColorRGBIntTimed(deviceId, r, g, b, transitionTimeMS)
 }
 
 // PutDeviceColorRGBInt does about the same as PutDeviceColorRGB except you can directly pass the rgb instead of a hex string
 func (tc *Client) PutDeviceColorRGBInt(deviceId string, r, g, b int) (model.Result, error) {
-	return tc.PutDeviceColorRGBIntTimed(deviceId, r, g, b, 0.5)
+	return tc.PutDeviceColorRGBIntTimed(deviceId, r, g, b, 500)
 }
 
 // PutDeviceColorRGBIntTimed does the same as PutDeviceColorRGBInt but it gives you the ability to change the speed at which the color changes
-func (tc *Client) PutDeviceColorRGBIntTimed(deviceId string, r, g, b int, transitionTime float64) (model.Result, error) {
+func (tc *Client) PutDeviceColorRGBIntTimed(deviceId string, r, g, b int, transitionTimeMS int) (model.Result, error) {
 	h, s, l := rgbToHsl(r, g, b)
 
-	return tc.PutDeviceColorHSLTimed(deviceId, h, s, l, transitionTime)
+	return tc.PutDeviceColorHSLTimed(deviceId, h, s, l, transitionTimeMS)
 }
 
 // PutDeviceColorHSL sets the color of the bulb using the HSL color notation
 // This is more effictive than RGB because RGB is always at full brightness, ("000000" is the same as "ffffff")
 func (tc *Client) PutDeviceColorHSL(deviceId string, hue float64, saturation float64, lightness float64) (model.Result, error) {
-	return tc.PutDeviceColorHSLTimed(deviceId, hue, saturation, lightness, 0.5)
+	return tc.PutDeviceColorHSLTimed(deviceId, hue, saturation, lightness, 500)
 }
 
 // PutDeviceColorHSLTimed does the same as PutDeviceColorHSL but it gives you the ability to change the speed at which the color changes
-func (tc *Client) PutDeviceColorHSLTimed(deviceId string, hue float64, saturation float64, lightness float64, transitionTime float64) (model.Result, error) {
+func (tc *Client) PutDeviceColorHSLTimed(deviceId string, hue float64, saturation float64, lightness float64, transitionTimeMS int) (model.Result, error) {
 	hueInt := int(mapRange(hue, 0, 360, 0, 65279))
 	saturationInt := int(mapRange(saturation, 0, 100, 0, 65279))
 	lightnessInt := int(mapRange(lightness, 0, 100, 0, 254))
 
-	payload := fmt.Sprintf(`{ "3311": [ {"5707": %d, "5708": %d, "5851": %d, "5712": %f}] }`, hueInt, saturationInt, lightnessInt, transitionTime)
+	payload := fmt.Sprintf(`{ "3311": [ {"5707": %d, "5708": %d, "5851": %d, "5712": %d}] }`, hueInt, saturationInt, lightnessInt, transitionTimeMS/100)
 	logrus.Infof("Payload is: %v", payload)
 	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
 	if err != nil {

--- a/tradfri/tradfri-client.go
+++ b/tradfri/tradfri-client.go
@@ -1,8 +1,10 @@
 package tradfri
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -10,6 +12,28 @@ import (
 	"github.com/eriklupander/tradfri-go/dtlscoap"
 	"github.com/eriklupander/tradfri-go/model"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	/** A "normal" remote */
+	DeviceTypeRemote = iota
+	/**
+	 * A remote which has been paired with another remote.
+	 * See https://www.reddit.com/r/tradfri/comments/6x1miq for details
+	 */
+	DeviceTypeSlaveRemote
+	/** A lightbulb */
+	DeviceTypeLightbulb
+	/** A smart plug */
+	DeviceTypePlug
+	/** A motion sensor (currently unsupported) */
+	DeviceTypeMotionSensor
+	/** A signal repeater */
+	DeviceTypeSignalRepeater
+	/** A smart blind */
+	DeviceTypeBlind
+	/** Symfonisk Remote */
+	DeviceTypeSoundRemote
 )
 
 // Client provides a declarative API for sending CoAP messages to the gateway over DTLS.
@@ -23,6 +47,9 @@ func NewTradfriClient(gatewayAddress, clientID, psk string) *Client {
 	client.dtlsclient = dtlscoap.NewDtlsClient(gatewayAddress, clientID, psk)
 	return client
 }
+
+// Yo who decided it would be a good idea to have the deviceId be an int in all the models, but here every function wants it as a string, its stupid
+// But i aint changin it because it could break code that depends on these functions (It would be a great change tho)
 
 // PutDeviceDimming sets the dimming property (0-255) of the specified device.
 // The device must be a bulb supporting dimming, otherwise the call if ineffectual.
@@ -69,8 +96,14 @@ func (tc *Client) PutDeviceState(deviceId string, power int, dimmer int, color s
 
 // PutDeviceColor sets the CIE 1931 color space x/y color, x and y must be between 0-65536 but note that
 // many combinations won't work. See CIE 1931 for more details.
+// It is not recommended to use these values to set colors, as it is often not supported by the gateway and is intended for internal use.
 func (tc *Client) PutDeviceColor(deviceId string, x, y int) (model.Result, error) {
-	payload := fmt.Sprintf(`{ "3311": [ {"5709": %d, "5710": %d}] }`, x, y)
+	return tc.PutDeviceColorTimed(deviceId, x, y, 0.5)
+}
+
+// PutDeviceColorTimed does the same as PutDeviceColor but it gives you the ability to change the speed at which the color changes
+func (tc *Client) PutDeviceColorTimed(deviceId string, x, y int, transitionTime float64) (model.Result, error) {
+	payload := fmt.Sprintf(`{ "3311": [ {"5709": %d, "5710": %d, "5712": %f}] }`, x, y, transitionTime)
 	logrus.Infof("Payload is: %v", payload)
 	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
 	if err != nil {
@@ -81,9 +114,46 @@ func (tc *Client) PutDeviceColor(deviceId string, x, y int) (model.Result, error
 }
 
 // PutDeviceColorRGB sets the color of the bulb using RGB hex string such as 8f2686 (purple). Note that
-// many colors doesn't seem to work. Not sure how the IKEA bulbs with color support works.
+// It does not use the built in rgb hex parameter as that does not work reliably, so the rgb is converted to hsl and that is sent
 func (tc *Client) PutDeviceColorRGB(deviceId, rgb string) (model.Result, error) {
-	payload := fmt.Sprintf(`{ "3311": [ {"5706": "%s"}] }`, rgb)
+	return tc.PutDeviceColorRGBTimed(deviceId, rgb, 0.5)
+}
+
+// PutDeviceColorRGBTimed does the same as PutDeviceColorRGB but it gives you the ability to change the speed at which the color changes
+func (tc *Client) PutDeviceColorRGBTimed(deviceId, rgb string, transitionTime float64) (model.Result, error) {
+	r, g, b, err := hexStringToRgb(rgb)
+	if err != nil {
+		return model.Result{}, err
+	}
+
+	return tc.PutDeviceColorRGBIntTimed(deviceId, r, g, b, transitionTime)
+}
+
+// PutDeviceColorRGBInt does about the same as PutDeviceColorRGB except you can directly pass the rgb instead of a hex string
+func (tc *Client) PutDeviceColorRGBInt(deviceId string, r, g, b int) (model.Result, error) {
+	return tc.PutDeviceColorRGBIntTimed(deviceId, r, g, b, 0.5)
+}
+
+// PutDeviceColorRGBIntTimed does the same as PutDeviceColorRGBInt but it gives you the ability to change the speed at which the color changes
+func (tc *Client) PutDeviceColorRGBIntTimed(deviceId string, r, g, b int, transitionTime float64) (model.Result, error) {
+	h, s, l := rgbToHsl(r, g, b)
+
+	return tc.PutDeviceColorHSLTimed(deviceId, h, s, l, transitionTime)
+}
+
+// PutDeviceColorHSL sets the color of the bulb using the HSL color notation
+// This is more effictive than RGB because RGB is always at full brightness, ("000000" is the same as "ffffff")
+func (tc *Client) PutDeviceColorHSL(deviceId string, hue float64, saturation float64, lightness float64) (model.Result, error) {
+	return tc.PutDeviceColorHSLTimed(deviceId, hue, saturation, lightness, 0.5)
+}
+
+// PutDeviceColorHSLTimed does the same as PutDeviceColorHSL but it gives you the ability to change the speed at which the color changes
+func (tc *Client) PutDeviceColorHSLTimed(deviceId string, hue float64, saturation float64, lightness float64, transitionTime float64) (model.Result, error) {
+	hueInt := int(mapRange(hue, 0, 360, 0, 65279))
+	saturationInt := int(mapRange(saturation, 0, 100, 0, 65279))
+	lightnessInt := int(mapRange(lightness, 0, 100, 0, 254))
+
+	payload := fmt.Sprintf(`{ "3311": [ {"5707": %d, "5708": %d, "5851": %d, "5712": %f}] }`, hueInt, saturationInt, lightnessInt, transitionTime)
 	logrus.Infof("Payload is: %v", payload)
 	resp, err := tc.Call(tc.dtlsclient.BuildPUTMessage("/15001/"+deviceId, payload))
 	if err != nil {
@@ -239,4 +309,67 @@ func (tc *Client) AuthExchange(clientId string) (model.TokenExchange, error) {
 // Call is just a proxy to the underlying DtlsClient Call
 func (tc *Client) Call(msg coap.Message) (coap.Message, error) {
 	return tc.dtlsclient.Call(msg)
+}
+
+func mapRange(x, inMin, inMax, outMin, outMax float64) float64 {
+	return (x-inMin)*(outMax-outMin)/(inMax-inMin) + outMin
+}
+
+func rgbToHsl(rInt int, gInt int, bInt int) (float64, float64, float64) {
+	var r float64 = float64(rInt) / 255
+	var g float64 = float64(gInt) / 255
+	var b float64 = float64(bInt) / 255
+
+	var maximum float64 = math.Max(r, math.Max(g, b))
+	var minimum float64 = math.Min(r, math.Min(g, b))
+
+	var h, s, l float64
+	h = (maximum + minimum) / 2
+	s = h
+	l = h
+
+	if maximum == minimum {
+		h = 0
+		s = 0
+	} else {
+		d := maximum - minimum
+
+		if l > 0.5 {
+			s = d / (2 - maximum - minimum)
+		} else {
+			s = d / (maximum + minimum)
+		}
+
+		switch maximum {
+		case r:
+			if g < b {
+				h = (g-b)/d + 6
+			} else {
+				h = (g-b)/d + 0
+			}
+			break
+		case g:
+			h = (b-r)/d + 2
+			break
+		case b:
+			h = (r-g)/d + 4
+			break
+		}
+		h /= 6
+	}
+
+	h *= 360
+	s *= 100
+	l *= 100
+
+	return h, s, l
+}
+
+func hexStringToRgb(hexString string) (int, int, int, error) {
+	bytes, err := hex.DecodeString(hexString)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return int(bytes[0]), int(bytes[1]), int(bytes[2]), nil
 }


### PR DESCRIPTION
I am using this program as a library for my own, and I was lacking some functions and clear labels.
I have renamed most of the Num3739 or similar properties to a name that describes the data they hold.
And I also added a function to fetch all devices connected to the gateway.

-- Edit
I added some more things:
- The putrgbcolor function now works correctly
- You can now send HSL color values
- It is possible to change the amount of time it takes for a bulb to change color
- The transitiontime element is now added to the device model
- You can now easily compare the device type to a list of correctly named constants