### PR TITLE
Add support for querying power control outlets

### DIFF
--- a/model/mapper.go
+++ b/model/mapper.go
@@ -37,6 +37,20 @@ func ToDeviceResponse(device Device) interface{} {
 			Position: device.BlindControl[0].Position,
 		}
 	}
+
+	// power outlet
+	if len(device.OutletControl) > 0 {
+		return PowerPlugResponse{
+			DeviceMetadata: DeviceMetadata{
+				Name:   device.Name,
+				Id:     device.DeviceId,
+				Type:   device.Metadata.TypeName,
+				Vendor: device.Metadata.Vendor,
+			},
+			Power: device.OutletControl[0].Power == 1,
+		}
+	}
+
 	return nil
 }
 

--- a/model/models.go
+++ b/model/models.go
@@ -22,6 +22,11 @@ type Device struct {
 		Dimmer           int     `json:"5851"`
 		DeviceId         int     `json:"9003"`
 	} `json:"3311"`
+	OutletControl []struct {
+		Power    int `json:"5850"`
+		Dimmer   int `json:"5851"`
+		DeviceId int `json:"9003"`
+	} `json:"3312"`
 	BlindControl []struct {
 		Position float32 `json:"5536"`
 		DeviceId int     `json:"9003"`


### PR DESCRIPTION
Previously power control outlets (https://www.ikea.com/gb/en/p/tradfri-wireless-control-outlet-00364477/) did support switching on and off but didn't return any information, which was confusing.

**Before:**
```
> curl http://localhost:8080/api/device/65537 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     4  100     4    0     0    468      0 --:--:-- --:--:-- --:--:--   500
```

**After:**
```
> curl http://localhost:8080/api/device/65537 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   139  100   139    0     0  13393      0 --:--:-- --:--:-- --:--:-- 13900
{
  "deviceMetadata": {
    "id": 65537,
    "name": "TRADFRI outlet",
    "vendor": "IKEA of Sweden",
    "type": "TRADFRI control outlet",
    "battery": 0
  },
  "power": false
}
```