### PR TITLE
feat: improved configs around server mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,23 +114,27 @@ func main() {
 	// Check running mode...
 	if serverMode {
 		logrus.Info("Running in server mode")
-		logrus.Infof("REST: %s:%d", listenHost, port)
-		logrus.Infof("gRPC: %s:%d", listenHost, grpcPort)
 
 		tc := tradfri.NewTradfriClient(gatewayAddress, clientID, psk)
 		wg := sync.WaitGroup{}
 		// REST
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			router.SetupChi(tc, fmt.Sprintf("%s:%d", listenHost, port))
-		}()
+		if port > 0 {
+			wg.Add(1)
+			logrus.Infof("REST: %s:%d", listenHost, port)
+			go func() {
+				defer wg.Done()
+				router.SetupChi(tc, fmt.Sprintf("%s:%d", listenHost, port))
+			}()
+		}
 		// gRPC
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			go registerGrpcServer(tc, fmt.Sprintf("%s:%d", listenHost, grpcPort))
-		}()
+		if grpcPort > 0 {
+			wg.Add(1)
+			logrus.Infof("gRPC: %s:%d", listenHost, grpcPort)
+			go func() {
+				defer wg.Done()
+				go registerGrpcServer(tc, fmt.Sprintf("%s:%d", listenHost, grpcPort))
+			}()
+		}
 
 		wg.Wait()
 	} else {

--- a/main.go
+++ b/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/eriklupander/dtls"
 	"log"
 	"net"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/eriklupander/dtls"
 
 	"github.com/eriklupander/tradfri-go/grpc_server"
 	pb "github.com/eriklupander/tradfri-go/grpc_server/golang"
@@ -38,8 +39,9 @@ func init() {
 	commandFlags.String("get", "", "URL to GET")
 	commandFlags.String("put", "", "URL to PUT")
 	commandFlags.String("payload", "", "payload for PUT")
-	commandFlags.Int("port", 8080, "port of the server")
-	commandFlags.Int("grpc_port", 8081, "port of the grpc server")
+	commandFlags.String("listen_host", "", "Host to listen on. Default empty allows connections from anywhere. Use \"127.0.0.1\" to only allow local connections.")
+	commandFlags.Int("port", 8080, "port of the REST server")
+	commandFlags.Int("grpc_port", 8081, "port of the gRPC server")
 
 	commandFlags.AddFlagSet(configFlags)
 	_ = commandFlags.Parse(os.Args[1:])
@@ -97,6 +99,7 @@ func main() {
 	get, getErr := commandFlags.GetString("get")
 	put, putErr := commandFlags.GetString("put")
 	payload, _ := commandFlags.GetString("payload")
+	listenHost, _ := commandFlags.GetString("listen_host")
 	port, _ := commandFlags.GetInt("port")
 	grpcPort, _ := commandFlags.GetInt("grpc_port")
 
@@ -111,14 +114,14 @@ func main() {
 	// Check running mode...
 	if serverMode {
 		logrus.Info("Running in server mode")
-		logrus.Infof("REST: %d", port)
-		logrus.Infof("gRPC: %d", grpcPort)
+		logrus.Infof("REST: %s:%d", listenHost, port)
+		logrus.Infof("gRPC: %s:%d", listenHost, grpcPort)
 
 		tc := tradfri.NewTradfriClient(gatewayAddress, clientID, psk)
 		// REST
-		go router.SetupChi(tc, port)
+		go router.SetupChi(tc, fmt.Sprintf("%s:%d", listenHost, port))
 		// Grpc
-		go registerGrpcServer(tc, grpcPort)
+		go registerGrpcServer(tc, fmt.Sprintf("%s:%d", listenHost, grpcPort))
 
 		wg := sync.WaitGroup{}
 		wg.Add(1)
@@ -183,7 +186,7 @@ func performTokenExchange(gatewayAddress, clientID, psk string) {
 	logrus.Info("Your configuration including the new PSK and clientID has been written to config.json, keep this file safe!")
 }
 
-func registerGrpcServer(tc *tradfri.Client, port int) {
+func registerGrpcServer(tc *tradfri.Client, listenAddress string) {
 	s := grpc.NewServer(
 		grpc_middleware.WithUnaryServerChain(
 			grpc_logrus.UnaryServerInterceptor(logrus.NewEntry(logrus.StandardLogger())),
@@ -193,9 +196,9 @@ func registerGrpcServer(tc *tradfri.Client, port int) {
 		),
 	)
 	pb.RegisterTradfriServiceServer(s, grpc_server.New(tc))
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	lis, err := net.Listen("tcp", listenAddress)
 	if err != nil {
-		logrus.Infof("failed to listen on grpc port %d: %v\n", port, err.Error())
+		logrus.Infof("failed to listen on grpc %s: %v\n", listenAddress, err.Error())
 		return
 	}
 	reflection.Register(s)

--- a/main.go
+++ b/main.go
@@ -40,8 +40,8 @@ func init() {
 	commandFlags.String("put", "", "URL to PUT")
 	commandFlags.String("payload", "", "payload for PUT")
 	commandFlags.String("listen_host", "", "Host to listen on. Default empty allows connections from anywhere. Use \"127.0.0.1\" to only allow local connections.")
-	commandFlags.Int("port", 8080, "port of the REST server")
-	commandFlags.Int("grpc_port", 8081, "port of the gRPC server")
+	commandFlags.Int("port", 8080, "Port of the REST server. Set to 0 to disable REST server.")
+	commandFlags.Int("grpc_port", 8081, "Port of the gRPC server. Set to 0 to disable gRPC server.")
 
 	commandFlags.AddFlagSet(configFlags)
 	_ = commandFlags.Parse(os.Args[1:])

--- a/main.go
+++ b/main.go
@@ -118,13 +118,20 @@ func main() {
 		logrus.Infof("gRPC: %s:%d", listenHost, grpcPort)
 
 		tc := tradfri.NewTradfriClient(gatewayAddress, clientID, psk)
-		// REST
-		go router.SetupChi(tc, fmt.Sprintf("%s:%d", listenHost, port))
-		// Grpc
-		go registerGrpcServer(tc, fmt.Sprintf("%s:%d", listenHost, grpcPort))
-
 		wg := sync.WaitGroup{}
+		// REST
 		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			router.SetupChi(tc, fmt.Sprintf("%s:%d", listenHost, port))
+		}()
+		// gRPC
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			go registerGrpcServer(tc, fmt.Sprintf("%s:%d", listenHost, grpcPort))
+		}()
+
 		wg.Wait()
 	} else {
 		// client mode

--- a/main.go
+++ b/main.go
@@ -28,17 +28,17 @@ var commandFlags = pflag.NewFlagSet("commands", pflag.ExitOnError)
 
 func init() {
 
-	configFlags.String("gateway_ip", "", "ip to your gateway. No protocol or port here!")
-	configFlags.String("gateway_address", "", "address to your gateway. Including port here!")
+	configFlags.String("gateway_ip", "", "IP to your gateway. No protocol or port here!")
+	configFlags.String("gateway_address", "", "Address to your gateway. Including port here!")
 	configFlags.String("psk", "", "Pre-shared key on bottom of Gateway")
 	configFlags.String("client_id", "", "Your client id, make something up or use the NNN-NNN-NNN on the bottom of your Gateway")
-	configFlags.String("loglevel", "info", "log leve. Allowed values: fatal, error, warn, info, debug, trace")
+	configFlags.String("loglevel", "info", "Log level. Allowed values: fatal, error, warn, info, debug, trace")
 
 	commandFlags.Bool("server", false, "Start in server mode?")
-	commandFlags.Bool("authenticate", false, "Perform PSK exchange")
+	commandFlags.Bool("authenticate", false, "Perform PSK exchange?")
 	commandFlags.String("get", "", "URL to GET")
 	commandFlags.String("put", "", "URL to PUT")
-	commandFlags.String("payload", "", "payload for PUT")
+	commandFlags.String("payload", "", "Payload for PUT")
 	commandFlags.String("listen_host", "", "Host to listen on. Default empty allows connections from anywhere. Use \"127.0.0.1\" to only allow local connections.")
 	commandFlags.Int("port", 8080, "Port of the REST server. Set to 0 to disable REST server.")
 	commandFlags.Int("grpc_port", 8081, "Port of the gRPC server. Set to 0 to disable gRPC server.")

--- a/router/router.go
+++ b/router/router.go
@@ -1,13 +1,13 @@
 package router
 
 import (
-	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/eriklupander/tradfri-go/tradfri"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/sirupsen/logrus"
-	"net/http"
-	"time"
 )
 
 const (
@@ -18,7 +18,7 @@ const (
 var tradfriClient *tradfri.Client
 
 // SetupChi sets up our HTTP router/muxer using Chi, a pointer to a Client must be passed.
-func SetupChi(client *tradfri.Client, port int) {
+func SetupChi(client *tradfri.Client, listenAddress string) {
 	tradfriClient = client
 	logger := middleware.RequestLogger(&middleware.DefaultLogFormatter{Logger: logrus.StandardLogger(), NoColor: false})
 	r := chi.NewRouter()
@@ -54,7 +54,7 @@ func SetupChi(client *tradfri.Client, port int) {
 	})
 
 	// Blocks here!
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), r); err !=  nil {
+	if err := http.ListenAndServe(listenAddress, r); err != nil {
 		logrus.WithError(err).Fatal("error starting HTTP server")
 	}
 }


### PR DESCRIPTION
Introducing two changes around how the server mode is configured:
1. Allowing specifying the host part of the listener address. The main use-case for this is allowing only local connections by setting `--listen_host 127.0.0.1` which is often preferable for security.
2. Allowing disabling both REST and gRPC servers by setting their port to 0

Also doing some minor housekeeping around the usage help.